### PR TITLE
Fix link attribute

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -86,6 +86,15 @@ describe('Markdown parser', function () {
       expect(link.attributes).toDeepEqual({ href: '/bar' });
     });
 
+    it('for link with one word and a title', function () {
+      const document = convert(`
+      [foo](/bar "title")
+      `);
+
+      const link = document.children[0].children[0].children[0];
+      expect(link.attributes).toDeepEqual({ href: '/bar', title: 'title' });
+    });
+
     it('for link', function () {
       const document = convert(`
       [this is a test](/bar)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -29,7 +29,9 @@ function handleAttrs(token: Token, type: string) {
       return { ordered: token.type.startsWith('ordered') };
     case 'link': {
       const attrs = Object.fromEntries(token.attrs);
-      return { href: attrs.href, title: attrs.title };
+      return attrs.title
+        ? { href: attrs.href, title: attrs.title }
+        : { href: attrs.href };
     }
     case 'image': {
       const attrs = Object.fromEntries(token.attrs);

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -24,7 +24,7 @@ describe('validate', function () {
         {
           error: {
             id: 'function-undefined',
-            message: "Undefined function 'baz'",
+            message: "Undefined function: 'baz'",
           },
         },
       ]);
@@ -79,7 +79,7 @@ describe('validate', function () {
           {
             error: {
               id: 'attribute-type-invalid',
-              message: "Attribute 'baz' must be type 'Boolean'",
+              message: "Attribute 'baz' must be type of 'Boolean'",
             },
           },
         ]);
@@ -94,13 +94,13 @@ describe('validate', function () {
           {
             error: {
               id: 'parameter-type-invalid',
-              message: "Parameter '0' of 'nested' must be type 'String'",
+              message: "Parameter '0' of 'nested' must be type of 'String'",
             },
           },
           {
             error: {
               id: 'parameter-type-invalid',
-              message: "Parameter '1' of 'nested' must be type 'Number'",
+              message: "Parameter '1' of 'nested' must be type of 'Number'",
             },
           },
         ]);
@@ -173,7 +173,7 @@ describe('validate', function () {
           {
             error: {
               id: 'parameter-missing-required',
-              message: "Missing required parameter 'req'",
+              message: "Missing required parameter: 'req'",
             },
           },
         ]);
@@ -199,7 +199,7 @@ describe('validate', function () {
               type: 'tag',
               error: {
                 id: 'parameter-undefined',
-                message: "Invalid parameter 'foo'",
+                message: "Invalid parameter: 'foo'",
               },
             },
           ]);
@@ -211,7 +211,7 @@ describe('validate', function () {
               type: 'tag',
               error: {
                 id: 'parameter-undefined',
-                message: "Invalid parameter '0'",
+                message: "Invalid parameter: '0'",
               },
             },
           ]);
@@ -223,7 +223,7 @@ describe('validate', function () {
               type: 'tag',
               error: {
                 id: 'parameter-undefined',
-                message: "Invalid parameter '0'",
+                message: "Invalid parameter: '0'",
               },
             },
           ]);
@@ -242,7 +242,7 @@ describe('validate', function () {
         const error: ValidationError = {
           id: 'attribute-type-invalid',
           level: 'error',
-          message: "Attribute 'href' must be type 'Link'",
+          message: "Attribute 'href' must be type of 'Link'",
         };
 
         return [error];
@@ -270,7 +270,7 @@ describe('validate', function () {
           error: {
             id: 'attribute-type-invalid',
             level: 'error',
-            message: "Attribute 'href' must be type 'Link'",
+            message: "Attribute 'href' must be type of 'Link'",
           },
         },
       ]);


### PR DESCRIPTION
Closes #28 

- Previous solution always resulted in return of title: undefined,
- This returns link title attribute only if actually present
- Updates failing tests for parser
- Updates failing tests for validator
