### PR TITLE
Add support for image titles

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -146,6 +146,22 @@ describe('Markdown parser', function () {
         content: 'This is a test\n',
       });
     });
+
+    it('for image with no title', function () {
+      const document = convert(`![foo](/url)`);
+      const image = document.children[0].children[0].children[0];
+      expect(image.attributes.title).toBe(undefined);
+      expect(image.attributes.src).toBe('/url');
+      expect(image.attributes.alt).toBe('foo');
+    });
+
+    it('for image with a title', function () {
+      const document = convert(`![foo](/url "title")`);
+      const image = document.children[0].children[0].children[0];
+      expect(image.attributes.title).toBe('title');
+      expect(image.attributes.src).toBe('/url');
+      expect(image.attributes.alt).toBe('foo');
+    });
   });
 
   it('handling a header', function () {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,7 +35,9 @@ function handleAttrs(token: Token, type: string) {
     }
     case 'image': {
       const attrs = Object.fromEntries(token.attrs);
-      return { alt: token.content, src: attrs.src };
+      return attrs.title
+        ? { alt: token.content, src: attrs.src, title: attrs.title }
+        : { alt: token.content, src: attrs.src };
     }
     case 'text':
     case 'code':

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -43,6 +43,7 @@ export const image: Schema = {
   attributes: {
     src: { type: String, required: true },
     alt: { type: String },
+    title: { type: String },
     // width/height attributes will need to be to be implemented as an extension to markdown-it
   },
 };


### PR DESCRIPTION
Adding support for image titles per CommonMark Spec: https://spec.commonmark.org/0.30/#example-571

This can be used downstream to wrap images with `<figure>` elements and with `<figcaption>` elements for the title where the attributes return a title.

Example:

```md
![foo](/url "title")
```

```html
<figure>
   <img src="/url" alt="foo" />
   <figcaption>title</figcaption>
</figure>
```