### PR TITLE
Add support for table alignment

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -162,6 +162,23 @@ describe('Markdown parser', function () {
       expect(image.attributes.src).toBe('/url');
       expect(image.attributes.alt).toBe('foo');
     });
+
+    it('for table with alignments', function () {
+      const document = convert(`
+      | Left | Center | Right |
+      | :--- | :----: | ----: |
+      | Left | Center | Right |
+      `);
+      const [thead, tbody] = document.children[0].children;
+
+      expect(thead.children[0].children[0].attributes.align).toBe('left');
+      expect(thead.children[0].children[1].attributes.align).toBe('center');
+      expect(thead.children[0].children[2].attributes.align).toBe('right');
+
+      expect(tbody.children[0].children[0].attributes.align).toBe('left');
+      expect(tbody.children[0].children[1].attributes.align).toBe('center');
+      expect(tbody.children[0].children[2].attributes.align).toBe('right');
+    });
   });
 
   it('handling a header', function () {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -48,6 +48,19 @@ function handleAttrs(token: Token, type: string) {
         ? { content: token.content }
         : { content: token.content, language };
     }
+    case 'td':
+    case 'th': {
+      const attrs = Object.fromEntries(token.attrs);
+      let align = 'left';
+      if (attrs.style) {
+        if (attrs.style.includes('center')) {
+          align = 'center';
+        } else if (attrs.style.includes('right')) {
+          align = 'right';
+        }
+      }
+      return { align };
+    }
     default:
       return {};
   }


### PR DESCRIPTION
In GFM, alignment in tables can be specified using colons in the delimiter line:

```
| Left | Center | Right |
| :--- | :----: | ----: |
| Left | Center | Right |
```

This PR updates to parser to carry over the `text-align` style property to the node’s `align` attribute.