### PR TITLE
Update to use customized React component instead of default component. #56

### DIFF
--- a/src/renderers/react/shared.ts
+++ b/src/renderers/react/shared.ts
@@ -8,9 +8,7 @@ export function tagName(
 ): string | Component {
   return typeof name !== 'string'
     ? 'Fragment'
-    : name[0] !== name[0].toUpperCase()
-    ? name
-    : components instanceof Function
-    ? components(name)
-    : components[name];
+    : !(components instanceof Function)
+    ? components[name] ?? (name[0] !== name[0].toUpperCase() ? name : undefined)
+    : components(name);
 }


### PR DESCRIPTION
This change is the solution (2) of https://github.com/markdoc/markdoc/issues/56

> (2) Change the priority of using default components, customized components and the function.
>
> (Update to use the default component only if no customized component is found.)
>
> Swap `return name` and `return components[name]` in `src/renderers/react/shared.ts`
