### PR TITLE
Test cases for CommonMark code_block node

### DIFF
--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -148,6 +148,19 @@
       attributes: { id: 'test', 'data-language': 'ruby' }
       children: ["example\n"]
 
+# https://spec.commonmark.org/0.30/#indented-code-block
+- name: code_block node via indentation
+  code: "\n\n    Code!\n\n"
+  expected:
+    - tag: pre
+      children: ['Code!']
+
+- name: code_block node via tab indentation
+  code: "\n\n\tCode!\n\n"
+  expected:
+    - tag: pre
+      children: ['Code!']
+
 - name: Frontmatter
   code: |
     ---


### PR DESCRIPTION
Closes #82

`markdown-it` related rule: https://github.com/markdown-it/markdown-it/blob/e5986bb7cca20ac95dc81e4741c08949bf01bb77/lib/rules_block/code.js