### PR TITLE
Bump version to v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
This includes:
-  https://github.com/markdoc/markdoc/pull/45 (support for image titles)
- https://github.com/markdoc/markdoc/pull/48 (bug with delimters)
- https://github.com/markdoc/markdoc/pull/49 (table alignment)
- https://github.com/markdoc/markdoc/pull/94 (patch a crash when parsing that caused a memory leak)