### PR TITLE
Fix TLD in README Shoutout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ This project uses the [MIT license](LICENSE).
 Special shout out to:
 
 - [@marcioAlmada](https://github.com/marcioAlmada) for providing us with the [@markdoc](https://github.com/markdoc) GitHub org.
-- [@koomen](https://github.com/koomen) for gifting us https://markdoc.dev.
+- [@koomen](https://github.com/koomen) for gifting us https://markdoc.io.


### PR DESCRIPTION
Currently the readme points to https://markdoc.dev, which points to a non-existent domain. It could be that this is the intended domain, yet the public-facing site is hosted at the .io TLD. If that is the case, the .dev could reroute to the .io. Otherwise, you could decide to call out that you decided to go to .io after the fact. There are many options. :)

I'm open to whatever you decide, but thought some fix should land. 