### PR TITLE
Pass node to validations so that location can be accessed for errors

### DIFF
--- a/src/schema-types/class.ts
+++ b/src/schema-types/class.ts
@@ -1,7 +1,7 @@
-import { CustomAttributeTypeInterface, ValidationError } from '../types';
+import { CustomAttributeTypeInterface, ValidationError, Node } from '../types';
 
 export class Class implements CustomAttributeTypeInterface {
-  validate(value: any): ValidationError[] {
+  validate(value: any, node: Node): ValidationError[] {
     if (typeof value === 'string' || typeof value === 'object') return [];
 
     return [
@@ -9,6 +9,7 @@ export class Class implements CustomAttributeTypeInterface {
         id: 'attribute-type-invalid',
         level: 'error',
         message: `Attribute 'class' must be type 'string | object'`,
+        location: node.location,
       },
     ];
   }

--- a/src/tags/partial.ts
+++ b/src/tags/partial.ts
@@ -1,7 +1,7 @@
 import type { Node, Config, Schema, ValidationError } from '../types';
 
 class PartialFile {
-  validate(file: any, config: Config): ValidationError[] {
+  validate(file: any, node: Node, config: Config): ValidationError[] {
     const { partials = {} } = config;
     const partial = partials[file];
 
@@ -11,6 +11,7 @@ class PartialFile {
           id: 'attribute-value-invalid',
           level: 'error',
           message: `Partial \`${file}\` not found. The 'file' attribute must be set in \`config.partials\``,
+          location: node.location,
         },
       ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type ConfigFunction = {
 
 export interface CustomAttributeTypeInterface {
   transform?(value: any, config: Config): Scalar;
-  validate?(value: any, config: Config): ValidationError[];
+  validate?(value: any, node: Node, config: Config): ValidationError[];
 }
 
 export interface CustomAttributeType {


### PR DESCRIPTION
This PR makes sure you get a reference to the node in validations so that you can return errors with more information eg: location.

I see there are some typing that could be improved eg: `export class Class implements CustomAttributeTypeInterface {` idk why its not typing `validate` correctly.  But I didn't want to change too much.

I made a breaking change, if you will, `validate(file: any, node: Node, config: Config)` although it didn't break any tests. I think it would be good practice to pass a single property as an object to avoid having to do any refactoring or breaking change.

Please let me know if you want me to change anything (or if this PR doesn't make sense).