### PR TITLE
makes parser public so that it can be extended

### DIFF
--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -4,10 +4,12 @@ import frontmatter from './plugins/frontmatter';
 import type Token from 'markdown-it/lib/token';
 
 export default class Tokenizer {
-  private parser: MarkdownIt;
+  parser: MarkdownIt;
 
   constructor(
-    config: MarkdownIt.Options & { allowIndentation?: boolean } = {}
+    config: MarkdownIt.Options & {
+      allowIndentation?: boolean;
+    } = {}
   ) {
     this.parser = new MarkdownIt(config);
     this.parser.use(annotations, 'annotations', {});


### PR DESCRIPTION
In order to add custom plugins we need to call `.use` coming out of markdownIt.

This PR simply makes parser public so that it's accessible.