### PR TITLE
Fix marktest

### DIFF
--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -1247,6 +1247,7 @@
 # Truthiness checks
 
 - name: Untruthy things are false
+  validation: false
   config:
     variables:
       foo: null


### PR DESCRIPTION
Validation error was showing up since `baz` was an undefined variable. This removes the validation check from that test. 
PTAL @rpaul-stripe 
