### PR TITLE
Improve error message for invalid attribute and add test

### DIFF
--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -234,7 +234,7 @@ describe('validate', function () {
 
   describe('attribute validation', () => {
     it('should return error on failure to match array', () => {
-      const example = '{% foo bar=baz() /%}';
+      const example = '{% foo jawn="cat" /%}';
       const schema = {
         tags: {
           foo: {
@@ -248,7 +248,7 @@ describe('validate', function () {
         },
       };
 
-      expect(validate('{% foo jawn="cat" /%}', schema)).toDeepEqualSubset([
+      expect(validate(example, schema)).toDeepEqualSubset([
         {
           type: 'tag',
           error: {

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -232,6 +232,34 @@ describe('validate', function () {
     });
   });
 
+  describe('attribute validation', () => {
+    it('should return error on failure to match array', () => {
+      const example = '{% foo bar=baz() /%}';
+      const schema = {
+        tags: {
+          foo: {
+            attributes: {
+              jawn: {
+                type: String,
+                matches: ['bar', 'baz', 'bat'],
+              },
+            },
+          },
+        },
+      };
+
+      expect(validate('{% foo jawn="cat" /%}', schema)).toDeepEqualSubset([
+        {
+          type: 'tag',
+          error: {
+            id: 'attribute-value-invalid',
+            message: `Attribute 'jawn' must match one of ["bar","baz","bat"]. Got 'cat' instead.`,
+          },
+        },
+      ]);
+    });
+  });
+
   describe('custom type registration example', () => {
     class Link {
       validate(value) {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -220,14 +220,14 @@ export default function validate(node: Node, config: Config) {
         level: errorLevel || 'error',
         message: `Attribute '${key}' must match one of ${JSON.stringify(
           matches
-        )}`,
+        )}. Got '${value}' instead.`,
       });
 
     if (matches instanceof RegExp && !matches.test(value))
       errors.push({
         id: 'attribute-value-invalid',
         level: errorLevel || 'error',
-        message: `Attribute '${key}' must match ${matches}`,
+        message: `Attribute '${key}' must match ${matches}. Got '${value}' instead.`,
       });
   }
 


### PR DESCRIPTION
## Problem

The error message for attribute invalidity could be improved by adding the value that was passed in. This would make some debugging easier.

In my use case, I have a glossary term that is invalid:

```
 {
      error: {
        id: 'attribute-value-invalid',
        level: 'error',
        message: `Attribute 'term' must match one of ["3D-Secure","3D-Secure-2", ...","wire-transfer"]`
      },
  }
```

It would be nice if it said what term was passed in. It would make cmd+f to replace the error easier instead of having to jump to the line number and look for it.


## Solution

Update copy + add test

