### PR TITLE
Move validation attribute test 

### DIFF
--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -258,6 +258,24 @@ describe('validate', function () {
         },
       ]);
     });
+
+    // https://github.com/markdoc/markdoc/issues/122
+    it('should validate partial file attributes', () => {
+      const example = `{% partial file="non-existent.md" /%}`;
+      const output = validate(example, {});
+
+      expect(output).toDeepEqualSubset([
+        {
+          type: 'tag',
+          error: {
+            id: 'attribute-value-invalid',
+            level: 'error',
+            message:
+              "Partial `non-existent.md` not found. The 'file' attribute must be set in `config.partials`",
+          },
+        },
+      ]);
+    });
   });
 
   describe('custom type registration example', () => {
@@ -364,23 +382,5 @@ describe('validate', function () {
     const output = validate(example, {});
 
     expect(output).toEqual([]);
-  });
-
-  // https://github.com/markdoc/markdoc/issues/122
-  it('should validate partial file attributes', () => {
-    const example = `{% partial file="non-existent.md" /%}`;
-    const output = validate(example, {});
-
-    expect(output).toDeepEqualSubset([
-      {
-        type: 'tag',
-        error: {
-          id: 'attribute-value-invalid',
-          level: 'error',
-          message:
-            "Partial `non-existent.md` not found. The 'file' attribute must be set in `config.partials`",
-        },
-      },
-    ]);
   });
 });


### PR DESCRIPTION
follow up from https://github.com/markdoc/markdoc/pull/182

I was not sure if it made sense to move any others because they were all functions.

r? @mfix-stripe 