### PR TITLE
Adds comment syntax to Markdoc

### DIFF
--- a/spec/marktest/index.ts
+++ b/spec/marktest/index.ts
@@ -18,7 +18,10 @@ class Loader extends yaml.loader.Loader {
   }
 }
 
-const tokenizer = new markdoc.Tokenizer({ allowIndentation: true, allowComments: true });
+const tokenizer = new markdoc.Tokenizer({
+  allowIndentation: true,
+  allowComments: true,
+});
 
 function parse(content: string, file?: string) {
   const tokens = tokenizer.tokenize(content);

--- a/spec/marktest/index.ts
+++ b/spec/marktest/index.ts
@@ -18,7 +18,7 @@ class Loader extends yaml.loader.Loader {
   }
 }
 
-const tokenizer = new markdoc.Tokenizer({ allowIndentation: true });
+const tokenizer = new markdoc.Tokenizer({ allowIndentation: true, allowComments: true });
 
 function parse(content: string, file?: string) {
   const tokens = tokenizer.tokenize(content);

--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -438,6 +438,51 @@
   expected: |
     <article><h1 class="foo bar">This is a test </h1></article>
 
+- name: Ignoring tags in fenced code blocks
+  code: |
+    ```javascript {% process=false %}
+    foo
+    {% bar %}
+    ```
+  expected:
+    - tag: pre
+      attributes:
+        data-language: javascript
+      children:
+        - "foo\n{% bar %}\n"
+
+- name: Using a backtick in a fenced code block string attribute
+  config:
+    nodes:
+      fence:
+        render: pre
+        attributes:
+          content:
+            type: String
+            render: false
+            required: true
+          language:
+            type: String
+            render: 'data-language'
+          process:
+            type: Boolean
+            render: false
+            default: true
+          title:
+            type: String
+
+  code: |
+    ~~~yaml {% title="this is a `test`" %}
+    example
+    ~~~
+  expected:
+    - tag: pre
+      attributes:
+        data-language: yaml
+        title: 'this is a `test`'
+      children:
+        - "example\n"
+
 - name: Conditional and variable in code example
   config:
     variables:
@@ -1503,3 +1548,47 @@
       children:
         - tag: p
           children: [testing]
+
+- name: Ignoring comments
+  code: |
+    # Example <!-- foo -->
+
+    This is a test <!-- bar
+    -->
+
+    <!--
+    baz
+    -->
+  expected:
+    - tag: h1
+      children: ['Example ']
+    - tag: p
+      children: ['This is a test ']
+
+- name: Escaped quotes in tag strings
+  config:
+    tags:
+      foo:
+        render: foo
+        attributes:
+          bar:
+            type: String
+  code: |
+    {% foo bar="this is a test of \"quoted\" strings" /%}
+  expected:
+    - tag: foo
+      attributes:
+        bar: 'this is a test of "quoted" strings'
+
+- name: Escaped quotes in tag strings with html renderer
+  renderer: html
+  config:
+    tags:
+      foo:
+        render: foo
+        attributes:
+          bar:
+            type: String
+  code: |
+    {% foo bar="this is a test of \"quoted\" strings" /%}
+  expected: <article><foo bar="this is a test of &quot;quoted&quot; strings"></foo></article>

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -7,7 +7,7 @@ import { any } from 'deep-assert';
 
 describe('Markdown parser', function () {
   const fence = '```';
-  const tokenizer = new Tokenizer({allowComments: true});
+  const tokenizer = new Tokenizer({ allowComments: true });
 
   function convert(example) {
     const content = example.replace(/\n\s+/gm, '\n').trim();
@@ -637,7 +637,7 @@ describe('Markdown parser', function () {
     }).not.toThrow();
   });
 
-  it('parsing comments', function() {
+  it('parsing comments', function () {
     const example = convert(`
     this is a test
 
@@ -647,9 +647,9 @@ describe('Markdown parser', function () {
     expect(example).toDeepEqualSubset({
       type: 'document',
       children: [
-        {type: 'paragraph'},
-        {type: 'comment', attributes: {content: 'foo'}}
-      ]
+        { type: 'paragraph' },
+        { type: 'comment', attributes: { content: 'foo' } },
+      ],
     });
   });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -7,7 +7,7 @@ import { any } from 'deep-assert';
 
 describe('Markdown parser', function () {
   const fence = '```';
-  const tokenizer = new Tokenizer();
+  const tokenizer = new Tokenizer({allowComments: true});
 
   function convert(example) {
     const content = example.replace(/\n\s+/gm, '\n').trim();
@@ -635,5 +635,21 @@ describe('Markdown parser', function () {
 {% /tag1 %}
     `);
     }).not.toThrow();
+  });
+
+  it('parsing comments', function() {
+    const example = convert(`
+    this is a test
+
+    <!-- foo -->
+    `);
+
+    expect(example).toDeepEqualSubset({
+      type: 'document',
+      children: [
+        {type: 'paragraph'},
+        {type: 'comment', attributes: {content: 'foo'}}
+      ]
+    });
   });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -45,6 +45,7 @@ function handleAttrs(token: Token, type: string) {
     }
     case 'text':
     case 'code':
+    case 'comment':
       return { content: (token.meta || {}).variable || token.content };
     case 'fence': {
       const [language] = token.info.split(' ', 1);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,6 +11,7 @@ export const document: Schema = {
     'tag',
     'fence',
     'blockquote',
+    'comment',
     'list',
     'hr',
   ],
@@ -189,6 +190,7 @@ export const inline: Schema = {
     'image',
     'hardbreak',
     'softbreak',
+    'comment',
   ],
 };
 
@@ -228,6 +230,12 @@ export const hardbreak: Schema = {
 export const softbreak: Schema = {
   transform() {
     return ' ';
+  },
+};
+
+export const comment = {
+  attributes: {
+    content: {type: String, required: true}
   },
 };
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -235,7 +235,7 @@ export const softbreak: Schema = {
 
 export const comment = {
   attributes: {
-    content: {type: String, required: true}
+    content: { type: String, required: true },
   },
 };
 

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -1,13 +1,17 @@
 import MarkdownIt from 'markdown-it/lib';
 import annotations from './plugins/annotations';
 import frontmatter from './plugins/frontmatter';
+import comments from './plugins/comments';
 import type Token from 'markdown-it/lib/token';
 
 export default class Tokenizer {
   private parser: MarkdownIt;
 
   constructor(
-    config: MarkdownIt.Options & { allowIndentation?: boolean } = {}
+    config: MarkdownIt.Options & {
+      allowIndentation?: boolean;
+      allowComments?: boolean;
+    } = {}
   ) {
     this.parser = new MarkdownIt(config);
     this.parser.use(annotations, 'annotations', {});
@@ -17,6 +21,8 @@ export default class Tokenizer {
       // Disable indented `code_block` support https://spec.commonmark.org/0.30/#indented-code-block
       'code',
     ]);
+
+    if (config.allowComments) this.parser.use(comments, 'comments', {});
   }
 
   tokenize(content: string): Token[] {

--- a/src/tokenizer/plugins/comments.test.ts
+++ b/src/tokenizer/plugins/comments.test.ts
@@ -1,0 +1,83 @@
+import Tokenizer from "..";
+
+describe('MarkdownIt Comments plugin', function() {
+  const tokenizer = new Tokenizer({allowComments: true});
+
+  function parse(example) {
+    const content = example.replace(/\n\s+/gm, '\n').trim();
+    return tokenizer.tokenize(content);
+  }
+
+  describe('inline comments', function() {
+    const output = [
+      {type: 'paragraph_open'},
+      {type: 'inline', children: [
+        {type: 'text', content: 'this is a test '},
+        {type: 'comment', content: 'example comment'},
+        {type: 'text', content: ' foo'},
+      ]},
+      {type: 'paragraph_close'},
+    ];
+
+    it('simple inline comment', function() {
+      const example = parse(`
+      this is a test <!-- example comment --> foo
+      `);
+
+      expect(example).toDeepEqualSubset(output)
+    });
+
+    it('inline comment with a newline', function() {
+      const example = parse(`
+      this is a test <!-- 
+        example comment
+        --> foo
+      `);
+
+      expect(example).toDeepEqualSubset(output)
+    });
+  });
+
+  describe('block comments', function() {
+    const output = [
+      {type: 'paragraph_open'},
+      {type: 'inline'},
+      {type: 'paragraph_close'},
+      {type: 'comment', content: 'example comment'},
+    ];
+
+    it('simple block comment after a paragraph', function() {
+      const example = parse(`
+      this is a test
+
+      <!--
+      example comment
+      -->
+      `);
+
+      expect(example).toDeepEqualSubset(output);
+    });
+
+    it('block comment with ending on same line as content', function() {
+      const example = parse(`
+      this is a test
+
+      <!--
+      example comment -->
+      `);
+
+      expect(example).toDeepEqualSubset(output);
+    });
+
+    it('block comment one one line', function() {
+      const example = parse(`
+      this is a test
+
+      <!-- example comment -->
+      `);
+
+      expect(example).toDeepEqualSubset(output);
+    });
+  });
+
+});

--- a/src/tokenizer/plugins/comments.test.ts
+++ b/src/tokenizer/plugins/comments.test.ts
@@ -47,6 +47,9 @@ describe('MarkdownIt Comments plugin', function () {
       { type: 'inline' },
       { type: 'paragraph_close' },
       { type: 'comment', content: 'example comment' },
+      { type: 'paragraph_open' },
+      { type: 'inline', content: 'foo' },
+      { type: 'paragraph_close' },
     ];
 
     it('simple block comment after a paragraph', function () {
@@ -56,6 +59,8 @@ describe('MarkdownIt Comments plugin', function () {
       <!--
       example comment
       -->
+      
+      foo
       `);
 
       expect(example).toDeepEqualSubset(output);
@@ -67,6 +72,8 @@ describe('MarkdownIt Comments plugin', function () {
 
       <!--
       example comment -->
+
+      foo
       `);
 
       expect(example).toDeepEqualSubset(output);
@@ -77,6 +84,8 @@ describe('MarkdownIt Comments plugin', function () {
       this is a test
 
       <!-- example comment -->
+
+      foo
       `);
 
       expect(example).toDeepEqualSubset(output);

--- a/src/tokenizer/plugins/comments.test.ts
+++ b/src/tokenizer/plugins/comments.test.ts
@@ -1,52 +1,55 @@
-import Tokenizer from "..";
+import Tokenizer from '..';
 
-describe('MarkdownIt Comments plugin', function() {
-  const tokenizer = new Tokenizer({allowComments: true});
+describe('MarkdownIt Comments plugin', function () {
+  const tokenizer = new Tokenizer({ allowComments: true });
 
   function parse(example) {
     const content = example.replace(/\n\s+/gm, '\n').trim();
     return tokenizer.tokenize(content);
   }
 
-  describe('inline comments', function() {
+  describe('inline comments', function () {
     const output = [
-      {type: 'paragraph_open'},
-      {type: 'inline', children: [
-        {type: 'text', content: 'this is a test '},
-        {type: 'comment', content: 'example comment'},
-        {type: 'text', content: ' foo'},
-      ]},
-      {type: 'paragraph_close'},
+      { type: 'paragraph_open' },
+      {
+        type: 'inline',
+        children: [
+          { type: 'text', content: 'this is a test ' },
+          { type: 'comment', content: 'example comment' },
+          { type: 'text', content: ' foo' },
+        ],
+      },
+      { type: 'paragraph_close' },
     ];
 
-    it('simple inline comment', function() {
+    it('simple inline comment', function () {
       const example = parse(`
       this is a test <!-- example comment --> foo
       `);
 
-      expect(example).toDeepEqualSubset(output)
+      expect(example).toDeepEqualSubset(output);
     });
 
-    it('inline comment with a newline', function() {
+    it('inline comment with a newline', function () {
       const example = parse(`
       this is a test <!-- 
         example comment
         --> foo
       `);
 
-      expect(example).toDeepEqualSubset(output)
+      expect(example).toDeepEqualSubset(output);
     });
   });
 
-  describe('block comments', function() {
+  describe('block comments', function () {
     const output = [
-      {type: 'paragraph_open'},
-      {type: 'inline'},
-      {type: 'paragraph_close'},
-      {type: 'comment', content: 'example comment'},
+      { type: 'paragraph_open' },
+      { type: 'inline' },
+      { type: 'paragraph_close' },
+      { type: 'comment', content: 'example comment' },
     ];
 
-    it('simple block comment after a paragraph', function() {
+    it('simple block comment after a paragraph', function () {
       const example = parse(`
       this is a test
 
@@ -58,7 +61,7 @@ describe('MarkdownIt Comments plugin', function() {
       expect(example).toDeepEqualSubset(output);
     });
 
-    it('block comment with ending on same line as content', function() {
+    it('block comment with ending on same line as content', function () {
       const example = parse(`
       this is a test
 
@@ -69,7 +72,7 @@ describe('MarkdownIt Comments plugin', function() {
       expect(example).toDeepEqualSubset(output);
     });
 
-    it('block comment one one line', function() {
+    it('block comment one one line', function () {
       const example = parse(`
       this is a test
 
@@ -79,5 +82,4 @@ describe('MarkdownIt Comments plugin', function() {
       expect(example).toDeepEqualSubset(output);
     });
   });
-
 });

--- a/src/tokenizer/plugins/comments.ts
+++ b/src/tokenizer/plugins/comments.ts
@@ -1,0 +1,50 @@
+import type MarkdownIt from 'markdown-it/lib';
+import type StateBlock from 'markdown-it/lib/rules_block/state_block';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline';
+
+const OPEN = '<!--';
+const CLOSE = '-->';
+
+function block(
+  state: StateBlock,
+  startLine: number,
+  endLine: number,
+  silent: boolean
+): boolean {
+  const start = state.bMarks[startLine] + state.tShift[startLine];
+  if (!state.src.startsWith(OPEN, start)) return false;
+
+  const close = state.src.indexOf(CLOSE, start);
+
+  if (!close) return false;
+  if (silent) return true;
+
+  const content = state.src.slice(start + OPEN.length, close);
+  const lines = content.split('\n').length;
+  const token = state.push('comment', '', 0);
+  token.content = content.trim();
+  token.map = [startLine, startLine + lines];
+  state.line = close;
+
+  return true;
+}
+
+function inline(state: StateInline, silent: boolean): boolean {
+  if (!state.src.startsWith(OPEN, state.pos)) return false;
+
+  const close = state.src.indexOf(CLOSE, state.pos);
+
+  if (!close) return false;
+  if (silent) return true;
+
+  const token = state.push('comment', '', 0);
+  token.content = state.src.slice(state.pos + OPEN.length, close).trim();
+  state.pos = close + CLOSE.length;
+
+  return true;
+}
+
+export default function plugin(md: MarkdownIt) {
+  md.block.ruler.before('table', 'comment', block, {alt: ['paragraph']});
+  md.inline.ruler.push('comment', inline);
+}

--- a/src/tokenizer/plugins/comments.ts
+++ b/src/tokenizer/plugins/comments.ts
@@ -37,8 +37,9 @@ function inline(state: StateInline, silent: boolean): boolean {
   if (!close) return false;
   if (silent) return true;
 
+  const content = state.src.slice(state.pos + OPEN.length, close);
   const token = state.push('comment', '', 0);
-  token.content = state.src.slice(state.pos + OPEN.length, close).trim();
+  token.content = content.trim();
   state.pos = close + CLOSE.length;
 
   return true;

--- a/src/tokenizer/plugins/comments.ts
+++ b/src/tokenizer/plugins/comments.ts
@@ -45,6 +45,6 @@ function inline(state: StateInline, silent: boolean): boolean {
 }
 
 export default function plugin(md: MarkdownIt) {
-  md.block.ruler.before('table', 'comment', block, {alt: ['paragraph']});
+  md.block.ruler.before('table', 'comment', block, { alt: ['paragraph'] });
   md.inline.ruler.push('comment', inline);
 }

--- a/src/tokenizer/plugins/comments.ts
+++ b/src/tokenizer/plugins/comments.ts
@@ -24,7 +24,7 @@ function block(
   const token = state.push('comment', '', 0);
   token.content = content.trim();
   token.map = [startLine, startLine + lines];
-  state.line = close;
+  state.line += lines;
 
   return true;
 }


### PR DESCRIPTION
This PR introduces support for comments in Markdoc. Some users (including Stripe) have previously relied on a no-op `{% comment %}` tag to be able to include non-rendering content in a document, but the content inside of the tag is still subject to parsing and validation, which creates some undesirable side effects, particularly when trying to comment out portions of a doc that contain other tags or malformed tags.

Rather than special-casing the behavior of the `{% comment %}` tag in a way that would undermine the consistency of tag semantics, we instead decided that Markdoc comments will use the standard HTML comment syntax (`<!-- -->`). This syntax is already supported for commenting in many CommonMark-compliant parsers, via broader support for arbitrary HTML markup inside of Markdown.

This PR adds a new plugin to MarkdownIt that just adds that comment syntax, making it possible to have HTML comments without having to enable general HTML parsing. The resulting comments are incorporated into the AST but are omitted from the rendered document (they do not get propagated through as HTML comments in the output). Users can override the schema definition for comment nodes and implement their own transform function if they would like different behavior, though we do not have support for rendering actual HTML comments via the render tree.

Things included in this PR:

* A MarkdownIt plugin that introduces block and inline parser rules for Markdoc comments 
* A new document node schema type for comments
* Schema updates to allow comment nodes at the document level and in inlines (I think this is all we need, but I may have missed something here)
* Test cases for the parser and for the MarkdownIt plugin
* Marktest cases to ensure that comments parse and do not render as expected
* A tweak to the parser code to make sure that the content of the comment gets applied to the AST node
* A new tokenizer option for turning on the plugin
* An assortment of unrelated marktest cases that I wrote to test various things recently and rolled into this PR 
