### PR TITLE
Wrap json object keys with "" if non-identifier

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -20,7 +20,7 @@ Markdoc is a **Markdown**-based \`syntax\` and _toolchain_ for creating ~~custom
 
     ![Alt](/image)
 
-{% callout #id   .class  .class2   a="check" b={"e":{f: 5}} c=8 d=[1,    "2",true] %}
+{% callout #id   .class  .class2   a="check" b={"e":{"with space": 5}} c=8 d=[1,    "2",true] %}
 Markdoc is open-source—check out it's [source](http://github.com/markdoc/markdoc) to see how it works.
 {% /callout %}
 
@@ -52,7 +52,14 @@ Markdoc is a **Markdown**-based \`syntax\` and _toolchain_ for creating ~~custom
 
 ![Alt](/image)
 
-{% callout #id .class .class2 a="check" b={e: {f: 5}} c=8 d=[1, "2", true] %}
+{% callout
+   #id
+   .class
+   .class2
+   a="check"
+   b={e: {"with space": 5}}
+   c=8
+   d=[1, "2", true] %}
 Markdoc is open-source—check out it's [source](http://github.com/markdoc/markdoc) to see how it works.
 {% /callout %}
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -47,7 +47,10 @@ function formatScalar(v: Value): string {
     return (
       '{' +
       Object.entries(v)
-        .map(([key, value]) => `${key}: ${formatScalar(value)}`)
+        .map(
+          ([key, value]) =>
+            `${isIdentifier(key) ? key : `"${key}"`}: ${formatScalar(value)}`
+        )
         .join(SEP) +
       '}'
     );


### PR DESCRIPTION
Fix bug in formatter: Wrap json object keys with "" if non-identifier

PTAL @rpaul-stripe 