### PR TITLE
Remove console.error from formatter

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -353,10 +353,7 @@ function* formatNode(n: Node, o: Options = {}) {
       yield* formatChildren(n, no);
       break;
     }
-    case 'error': {
-      console.error(n);
-      break;
-    }
+    case 'error':
     case 'node':
       break;
   }


### PR DESCRIPTION
@rpaul-stripe WDYT about this? It feels weird to me to have this random side effect in the middle of the formatter. Should we yield the errors contents instead?

How do you want to approach this? 