### PR TITLE
Validation improvements

### DIFF
--- a/src/schema-types/id.ts
+++ b/src/schema-types/id.ts
@@ -1,0 +1,15 @@
+import { CustomAttributeTypeInterface, ValidationError } from '../types';
+
+export class Id implements CustomAttributeTypeInterface {
+  validate(value: any): ValidationError[] {
+    if (typeof value === 'string' && value.match(/^[a-zA-Z]/)) return [];
+
+    return [
+      {
+        id: 'attribute-value-invalid',
+        level: 'error',
+        message: "The 'id' attribute must start with a letter",
+      },
+    ];
+  }
+}

--- a/src/schema-types/id.ts
+++ b/src/schema-types/id.ts
@@ -1,4 +1,4 @@
-import { CustomAttributeTypeInterface, ValidationError } from '../types';
+import type { CustomAttributeTypeInterface, ValidationError } from '../types';
 
 export class Id implements CustomAttributeTypeInterface {
   validate(value: any): ValidationError[] {

--- a/src/tags/conditional.ts
+++ b/src/tags/conditional.ts
@@ -1,6 +1,6 @@
 import { isPromise } from '../utils';
 
-import type { Node, RenderableTreeNode, Schema, Value } from '../types';
+import { Node, RenderableTreeNode, Schema, Value } from '../types';
 
 type Condition = { condition: Value; children: Node[] };
 

--- a/src/tags/conditional.ts
+++ b/src/tags/conditional.ts
@@ -1,6 +1,6 @@
 import { isPromise } from '../utils';
 
-import { Node, RenderableTreeNode, Schema, Value } from '../types';
+import type { Node, RenderableTreeNode, Schema, Value } from '../types';
 
 type Condition = { condition: Value; children: Node[] };
 

--- a/src/tags/partial.ts
+++ b/src/tags/partial.ts
@@ -1,4 +1,4 @@
-import type { Node, Config, Schema, ValidationError } from '../types';
+import { Node, Config, Schema, ValidationError } from '../types';
 
 class PartialFile {
   validate(file: any, config: Config): ValidationError[] {
@@ -19,6 +19,7 @@ class PartialFile {
 }
 
 export const partial: Schema = {
+  inline: false,
   selfClosing: true,
   attributes: {
     file: { type: PartialFile, render: false, required: true },

--- a/src/tags/partial.ts
+++ b/src/tags/partial.ts
@@ -1,4 +1,4 @@
-import { Node, Config, Schema, ValidationError } from '../types';
+import type { Node, Config, Schema, ValidationError } from '../types';
 
 class PartialFile {
   validate(file: any, config: Config): ValidationError[] {

--- a/src/tags/table.ts
+++ b/src/tags/table.ts
@@ -1,5 +1,6 @@
-import type { Schema } from '../types';
+import { Schema } from '../types';
 
 export const table: Schema = {
   children: ['table'],
+  inline: false,
 };

--- a/src/tags/table.ts
+++ b/src/tags/table.ts
@@ -1,4 +1,4 @@
-import { Schema } from '../types';
+import type { Schema } from '../types';
 
 export const table: Schema = {
   children: ['table'],

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -2,12 +2,27 @@ import Tag from './tag';
 import { Class } from './schema-types/class';
 import { isPromise } from './utils';
 import type { Config, Node, NodeType, Schema, Transformer } from './types';
+import { Value } from '..';
 
 type AttributesSchema = Schema['attributes'];
 
 export const globalAttributes: AttributesSchema = {
   class: { type: Class, render: true },
-  id: { type: String, render: true },
+  id: {
+    type: String,
+    render: true,
+    validate(value: Value, _config: Config) {
+      return typeof value === 'string' && value.match(/^[a-zA-Z]/)
+        ? []
+        : [
+            {
+              id: 'attribute-value-invalid',
+              level: 'error',
+              message: 'The id attribute must start with a letter',
+            },
+          ];
+    },
+  },
 };
 
 export default {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -18,7 +18,7 @@ export const globalAttributes: AttributesSchema = {
             {
               id: 'attribute-value-invalid',
               level: 'error',
-              message: 'The id attribute must start with a letter',
+              message: "The 'id' attribute must start with a letter",
             },
           ];
     },

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,28 +1,14 @@
 import Tag from './tag';
 import { Class } from './schema-types/class';
+import { Id } from './schema-types/id';
 import { isPromise } from './utils';
 import type { Config, Node, NodeType, Schema, Transformer } from './types';
-import { Value } from '..';
 
 type AttributesSchema = Schema['attributes'];
 
 export const globalAttributes: AttributesSchema = {
   class: { type: Class, render: true },
-  id: {
-    type: String,
-    render: true,
-    validate(value: Value, _config: Config) {
-      return typeof value === 'string' && value.match(/^[a-zA-Z]/)
-        ? []
-        : [
-            {
-              id: 'attribute-value-invalid',
-              level: 'error',
-              message: "The 'id' attribute must start with a letter",
-            },
-          ];
-    },
-  },
+  id: { type: Id, render: true },
 };
 
 export default {

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,7 @@ export type Schema<C extends Config = Config, R = string> = {
   children?: string[];
   attributes?: Record<string, SchemaAttribute>;
   selfClosing?: boolean;
+  inline?: boolean;
   transform?(node: Node, config: C): MaybePromise<RenderableTreeNodes>;
   validate?(node: Node, config: C): MaybePromise<ValidationError[]>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,7 @@ export type SchemaAttribute = {
   required?: boolean;
   matches?: SchemaMatches | ((config: Config) => SchemaMatches);
   errorLevel?: ValidationError['level'];
+  validate?(value: Value, config: Config): ValidationError[];
 };
 
 export type SchemaMatches = RegExp | string[] | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,6 @@ export type SchemaAttribute = {
   required?: boolean;
   matches?: SchemaMatches | ((config: Config) => SchemaMatches);
   errorLevel?: ValidationError['level'];
-  validate?(value: Value, config: Config): ValidationError[];
 };
 
 export type SchemaMatches = RegExp | string[] | null;

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -343,37 +343,6 @@ bar
       const hash = validate(`# foo {% id="#bar" %}`, {});
       expect(hash[0]?.error.id).toEqual('attribute-value-invalid');
     });
-
-    it('with custom validation function', () => {
-      const config = {
-        tags: {
-          foo: {
-            attributes: {
-              bar: {
-                type: String,
-                validate(value, _config) {
-                  return value === 'baz'
-                    ? []
-                    : [
-                        {
-                          id: 'attribute-should-be-baz',
-                          level: 'error',
-                          message: 'Value should be "baz"',
-                        },
-                      ];
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const correct = validate(`{% foo bar="baz" /%}`, config);
-      expect(correct).toEqual([]);
-
-      const invalid = validate(`{% foo bar="qux" /%}`, config);
-      expect(invalid[0]?.error.id).toEqual('attribute-should-be-baz');
-    });
   });
 
   describe('custom type registration example', () => {

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -232,6 +232,55 @@ describe('validate', function () {
     });
   });
 
+  describe('inline rule', () => {
+    const config = {
+        tags: {
+          foo: { inline: true },
+          bar: { inline: false },
+          baz: {  },
+        }
+      };
+
+    it('allows inline or block when undefined', () => {
+      const inline = validate(`this is inline {% baz %}bar{% /baz %}`, config);
+      expect(inline).toEqual([]);
+
+      const block = validate(`
+{% baz %}
+bar
+{% /baz %}
+      `, config);
+      expect(block).toEqual([]);
+
+    });
+
+    it('validates inline tag', () => {
+      const correct = validate(`this is inline {% foo %}bar{% /foo %}`, config);
+      expect(correct).toEqual([]);
+
+      const wrong = validate(`
+{% foo %}
+bar
+{% /foo %}
+      `, config);
+      expect(wrong[0]?.error.id).toEqual('tag-placement-invalid');
+      expect(wrong[0]?.error.message).toContain('should be inline'); 
+    });
+
+
+    it('validates block tag', () => {
+      const correct = validate(`
+{% bar %}
+bar
+{% /bar %}
+`, config);
+      expect(correct).toEqual([]);
+      const wrong = validate(`this is inline {% bar %}bar{% /bar %}`, config);
+      expect(wrong[0]?.error.id).toEqual('tag-placement-invalid');
+      expect(wrong[0]?.error.message).toContain('should be block'); 
+    });
+  });
+
   describe('attribute validation', () => {
     it('should return error on failure to match array', () => {
       const example = '{% foo jawn="cat" /%}';

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -234,50 +234,57 @@ describe('validate', function () {
 
   describe('inline rule', () => {
     const config = {
-        tags: {
-          foo: { inline: true },
-          bar: { inline: false },
-          baz: {  },
-        }
-      };
+      tags: {
+        foo: { inline: true },
+        bar: { inline: false },
+        baz: {},
+      },
+    };
 
     it('allows inline or block when undefined', () => {
       const inline = validate(`this is inline {% baz %}bar{% /baz %}`, config);
       expect(inline).toEqual([]);
 
-      const block = validate(`
+      const block = validate(
+        `
 {% baz %}
 bar
 {% /baz %}
-      `, config);
+      `,
+        config
+      );
       expect(block).toEqual([]);
-
     });
 
     it('validates inline tag', () => {
       const correct = validate(`this is inline {% foo %}bar{% /foo %}`, config);
       expect(correct).toEqual([]);
 
-      const wrong = validate(`
+      const wrong = validate(
+        `
 {% foo %}
 bar
 {% /foo %}
-      `, config);
+      `,
+        config
+      );
       expect(wrong[0]?.error.id).toEqual('tag-placement-invalid');
-      expect(wrong[0]?.error.message).toContain('should be inline'); 
+      expect(wrong[0]?.error.message).toContain('should be inline');
     });
 
-
     it('validates block tag', () => {
-      const correct = validate(`
+      const correct = validate(
+        `
 {% bar %}
 bar
 {% /bar %}
-`, config);
+`,
+        config
+      );
       expect(correct).toEqual([]);
       const wrong = validate(`this is inline {% bar %}bar{% /bar %}`, config);
       expect(wrong[0]?.error.id).toEqual('tag-placement-invalid');
-      expect(wrong[0]?.error.message).toContain('should be block'); 
+      expect(wrong[0]?.error.message).toContain('should be block');
     });
   });
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -141,8 +141,10 @@ export default function validator(node: Node, config: Config) {
     errors.push({
       id: 'tag-placement-invalid',
       level: 'critical',
-      message: `'${node.tag}' tag should be ${schema.inline ? 'inline' : 'block'}`
-    })
+      message: `'${node.tag}' tag should be ${
+        schema.inline ? 'inline' : 'block'
+      }`,
+    });
 
   if (schema.selfClosing && node.children.length > 0)
     errors.push({

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -137,6 +137,13 @@ export default function validator(node: Node, config: Config) {
     return errors;
   }
 
+  if (schema.inline != undefined && node.inline !== schema.inline)
+    errors.push({
+      id: 'tag-placement-invalid',
+      level: 'critical',
+      message: `'${node.tag}' tag should be ${schema.inline ? 'inline' : 'block'}`
+    })
+
   if (schema.selfClosing && node.children.length > 0)
     errors.push({
       id: 'tag-selfclosing-has-children',

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -214,9 +214,6 @@ export default function validator(node: Node, config: Config) {
       }
     }
 
-    if (typeof attrib.validate === 'function')
-      errors.push(...attrib.validate(value, config));
-
     if (typeof matches === 'function') matches = matches(config);
 
     if (Array.isArray(matches) && !matches.includes(value))

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -190,12 +190,6 @@ export default function validator(node: Node, config: Config) {
     }
 
     value = value as string;
-    if (key === 'id' && value.match(/^[0-9]/))
-      errors.push({
-        id: 'attribute-value-invalid',
-        level: 'error',
-        message: 'The id attribute must not start with a number',
-      });
 
     if (type) {
       const valid = validateType(type, value, config);
@@ -210,6 +204,9 @@ export default function validator(node: Node, config: Config) {
         errors.push(...valid);
       }
     }
+
+    if (typeof attrib.validate === 'function')
+      errors.push(...attrib.validate(value, config));
 
     if (typeof matches === 'function') matches = matches(config);
 


### PR DESCRIPTION
- Adds support for a `validate` function inside of an attribute schema
	- Optional property that allows performing arbitrary logic to validate the value of an attribute
- Adds a `validate` function for the global `id` attribute to make sure that the id starts with a letter
- Adds an `inline` schema property that indicates whether a tag should be used as a block or inline
	- When property is undefined, it allows it to be used as either block or inline
	- Adds validation rule that returns a "critical" error when the tag is used incorrectly
	- Adds an `inline` property value to the partial and table tags