### PR TITLE
Tweaks the RenderableTreeNode type

### DIFF
--- a/src/renderers/html.ts
+++ b/src/renderers/html.ts
@@ -23,7 +23,7 @@ const voidElements = new Set([
 
 export default function render(node: RenderableTreeNodes): string {
   if (typeof node === 'string' || typeof node === 'number')
-    return escapeHtml(node);
+    return escapeHtml(String(node));
 
   if (Array.isArray(node)) return node.map(render).join('');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export type NodeType =
 
 export type Primitive = null | boolean | number | string;
 
-export type RenderableTreeNode = Tag | string | null;
+export type RenderableTreeNode = Tag | Primitive;
 export type RenderableTreeNodes = RenderableTreeNode | RenderableTreeNode[];
 
 export type Scalar = Primitive | Scalar[] | { [key: string]: Scalar };


### PR DESCRIPTION
This PR tweaks the type of the RenderableTreeNode in order to reflect that other primitives besides string and null can be included in the output.