### PR TITLE
fix transform return type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ import transforms from './src/transforms';
 import { parseTags, isPromise } from './src/utils';
 import validator from './src/validator';
 
-import type { Node } from './src/types';
+import type { MaybePromise, Node } from './src/types';
 import type Token from 'markdown-it/lib/token';
 import type { Config, RenderableTreeNode, ValidateError } from './src/types';
 
@@ -65,11 +65,11 @@ export function resolve<C extends Config = Config>(
 export function transform<C extends Config = Config>(
   node: Node,
   config?: C
-): RenderableTreeNode;
+): MaybePromise<RenderableTreeNode>;
 export function transform<C extends Config = Config>(
   nodes: Node[],
   config?: C
-): RenderableTreeNode[];
+): MaybePromise<RenderableTreeNode[]>;
 export function transform<C extends Config = Config>(
   nodes: any,
   options?: C


### PR DESCRIPTION
Hello.

I love this useful library and recently tried an async transform. https://github.com/markdoc/markdoc/pull/109
Then I found what seems to be a small mistake in the type definition.
<img width="626" alt="markdoc" src="https://user-images.githubusercontent.com/14846330/197355459-5c1d33de-305b-43ed-b2b6-6a96d21081ba.png">

I haven't read much of the code, but I am thinking that maybe I can fix this type.
I would be happy to check it out if you would like.

Thanks!