### PR TITLE
Formatter fixed: escape markdown characters in "text" nodes; fix nested fences

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -640,4 +640,19 @@ Package.json
 
     check(source, expected);
   });
+
+  it('nested fences', () => {
+    const source = `
+${'`'.repeat(4)}
+
+${'`'.repeat(3)}
+Fence within a fence
+${'`'.repeat(3)}
+
+
+${'`'.repeat(4)}
+`;
+
+    check(source, source);
+  });
 });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -137,6 +137,24 @@ subtitle: Subtitle
     stable(source);
   });
 
+  it('content edge cases', () => {
+    const source = `
+\\* Asterisk
+
+**/docs/\\***
+
+~~**a \\_sentence\\_ with \\_underscores**~~
+
+- Item with \\[brackets\\]
+
+\`\`\`
+\\*\\_[\\[]
+\`\`\`
+`;
+
+    check(source, source);
+  });
+
   it('complex attributes', () => {
     const source = `{% if $gates["<string_key>"].test["@var"] id="id with space" class="class with space" /%}`;
     const expected = `{% if

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -117,6 +117,12 @@ function* trimStart(g: Generator<string>) {
   yield* g;
 }
 
+function* escapeMarkdownCharacters(g: Generator<string>) {
+  for (const s of g) {
+    yield s.replace(/[_*[\]\\]/g, '\\$&');
+  }
+}
+
 function* formatNode(n: Node, o: Options = {}) {
   const no = { ...o, parent: n };
   const indent = SPACE.repeat(no.indent || 0);
@@ -178,7 +184,7 @@ function* formatNode(n: Node, o: Options = {}) {
     }
     case 'text': {
       if (Ast.isAst(n.attributes.content)) yield OPEN + SPACE;
-      yield* formatValue(n.attributes.content, no);
+      yield* escapeMarkdownCharacters(formatValue(n.attributes.content));
       if (Ast.isAst(n.attributes.content)) yield SPACE + CLOSE;
       break;
     }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -205,7 +205,16 @@ function* formatNode(n: Node, o: Options = {}) {
     case 'fence': {
       yield NL;
       yield indent;
-      yield '```';
+
+      const innerFence = n.attributes.content.match(/`{3,}/g) || [];
+
+      const innerFenceLength = innerFence
+        .map((s: string) => s.length)
+        .reduce(max, 0);
+
+      const boundary = '`'.repeat(innerFenceLength ? innerFenceLength + 1 : 3);
+
+      yield boundary;
       if (n.attributes.language) yield n.attributes.language;
       if (n.annotations.length) yield SPACE;
       yield* formatAnnotations(n);
@@ -213,7 +222,7 @@ function* formatNode(n: Node, o: Options = {}) {
       yield indent;
       // TODO use formatChildren once we can differentiate inline from block tags within fences
       yield n.attributes.content.split(NL).join(NL + indent); // yield* formatChildren(n, no);
-      yield '```';
+      yield boundary;
       yield NL;
       break;
     }


### PR DESCRIPTION
- Escape markdown characters in "text" nodes
- Fix nested fences