### PR TITLE
Preserve list marker

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -445,6 +445,41 @@ Yes!
     check(source, expected);
     stable(expected);
   });
+
+  it('preserving list marker', () => {
+    const source = `
+- foo
+- bar
+* baz
+* qux
+
+
+1) foo
+2) bar
+3) baz
+1. foo
+2. bar
+3. baz
+`;
+    const expected = `
+- foo
+- bar
+
+* baz
+* qux
+
+1) foo
+1) bar
+1) baz
+
+1. foo
+1. bar
+1. baz
+`;
+    check(source, expected);
+    stable(expected);
+  });
+
   it('"loose" lists', () => {
     const source = `
 - One
@@ -558,7 +593,7 @@ Yes!
        Markdoc uses…`;
 
     const expected = `
-- Create your CNAME record
+* Create your CNAME record
 
   1. Click **Add record**.
 
@@ -632,9 +667,9 @@ Yes!
 `;
 
     const expected = `
-- **One**{% colspan=1 %}
-- **Two**{% colspan=2 %}
-- **Three**{% colspan=3 %}
+* **One**{% colspan=1 %}
+* **Two**{% colspan=2 %}
+* **Three**{% colspan=3 %}
 `;
 
     check(source, expected);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -287,10 +287,12 @@ function* formatNode(n: Node, o: Options = {}) {
       break;
     }
     case 'list': {
-      const prefix = n.attributes.ordered ? OL : UL;
+      const prefix = n.attributes.ordered
+        ? `1${n.attributes.marker ?? '.'}`
+        : n.attributes.marker ?? '*';
       for (const child of n.children) {
-        const d = format(child, increment(no, prefix.length)).trim();
-        yield NL + indent + prefix + d;
+        const d = format(child, increment(no, prefix.length + 1)).trim();
+        yield NL + indent + prefix + ' ' + d;
       }
       yield NL;
       break;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -12,8 +12,8 @@ type Options = {
 const SPACE = ' ';
 const SEP = ', '; // Value separator
 const NL = '\n'; //  Newline
-const OL = '1. '; // Ordered list
-const UL = '- '; //  Unordered list
+const OL = '.'; // Ordered list
+const UL = '-'; //  Unordered list
 
 const MAX_TAG_OPENING_WIDTH = 80;
 
@@ -288,8 +288,8 @@ function* formatNode(n: Node, o: Options = {}) {
     }
     case 'list': {
       const prefix = n.attributes.ordered
-        ? `1${n.attributes.marker ?? '.'}`
-        : n.attributes.marker ?? '*';
+        ? `1${n.attributes.marker ?? OL}`
+        : n.attributes.marker ?? UL;
       for (const child of n.children) {
         const d = format(child, increment(no, prefix.length + 1)).trim();
         yield NL + indent + prefix + ' ' + d;
@@ -355,7 +355,7 @@ function* formatNode(n: Node, o: Options = {}) {
               yield indent + '---';
             }
             for (const d of row) {
-              yield NL + indent + UL + d;
+              yield NL + indent + UL + ' ' + d;
             }
           }
         }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,7 +31,10 @@ function handleAttrs(token: Token, type: string) {
     case 'heading':
       return { level: Number(token.tag.replace('h', '')) };
     case 'list':
-      return { ordered: token.type.startsWith('ordered') };
+      return {
+        ordered: token.type.startsWith('ordered'),
+        marker: token.markup,
+      };
     case 'link': {
       const attrs = Object.fromEntries(token.attrs);
       return attrs.title

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -101,7 +101,7 @@ export const list: Schema = {
   children: ['item'],
   attributes: {
     ordered: { type: Boolean, render: false, required: true },
-    marker: { type: String, render: false }
+    marker: { type: String, render: false },
   },
   transform(node, config) {
     return new Tag(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -101,6 +101,7 @@ export const list: Schema = {
   children: ['item'],
   attributes: {
     ordered: { type: Boolean, render: false, required: true },
+    marker: { type: String, render: false }
   },
   transform(node, config) {
     return new Tag(


### PR DESCRIPTION
This PR adds an attribute called `marker` to `list` nodes that preserves the marker symbol used for the list in the source document. For ordered lists, this is either `)` or `.` and for unordered lists it is either `-` or `*`. The marker is already exposed by the tokenizer, so the parser just has to take this value and assign it to the attribute.

This PR also modifies the formatter so that it uses the marker provided by the source content when available instead of defaulting to a specific value. Previously, the formatter was programmed to always use `1.` for ordered lists and `-` for unordered lists in order to enforce consistency.

The problem that has arisen with this behavior is that in cases where there are two separate lists that appear in immediate succession in a document, the marker needs to be different in order for the parser to correctly identify them as separate lists. This behavior is demonstrated by [Example 301](https://spec.commonmark.org/0.30/#example-301) in the CommonMark specification. Making the formatter respect the original marker used in the source content ensures that it will not erroneously combine separate lists that appear in sequence.