### PR TITLE
Improves the way the validator displays matches with many possible values

### DIFF
--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -315,6 +315,33 @@ bar
       ]);
     });
 
+    it('Elides excess values in matches check', () => {
+      const example = '{% foo jawn="cat" /%}';
+      const schema = {
+        tags: {
+          foo: {
+            attributes: {
+              jawn: {
+                type: String,
+                matches: Array.from('foobarbazqux'),
+              },
+            },
+          },
+        },
+      };
+
+      const output = validate(example, schema);
+      expect(output).toDeepEqualSubset([
+        {
+          type: 'tag',
+          error: {
+            id: 'attribute-value-invalid',
+            message: `Attribute 'jawn' must match one of ["f","o","o","b","a","r","b","a", ... 4 more]. Got 'cat' instead.`,
+          },
+        },
+      ]);
+    });
+
     // https://github.com/markdoc/markdoc/issues/122
     it('should validate partial file attributes', () => {
       const example = `{% partial file="non-existent.md" /%}`;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -121,6 +121,12 @@ function validateFunction(fn: Function, config: Config): ValidationError[] {
   return errors;
 }
 
+function displayMatches(matches: any[], n: number) {
+  if (matches.length <= n) return JSON.stringify(matches);
+  const items = matches.slice(0, n).map((item) => JSON.stringify(item));
+  return `[${items.join(',')}, ... ${matches.length - n} more]`;
+}
+
 export default function validator(node: Node, config: Config) {
   const schema = node.findSchema(config);
   const errors: ValidationError[] = [...(node.errors || [])];
@@ -220,8 +226,9 @@ export default function validator(node: Node, config: Config) {
       errors.push({
         id: 'attribute-value-invalid',
         level: errorLevel || 'error',
-        message: `Attribute '${key}' must match one of ${JSON.stringify(
-          matches
+        message: `Attribute '${key}' must match one of ${displayMatches(
+          matches,
+          8
         )}. Got '${value}' instead.`,
       });
 


### PR DESCRIPTION
When a `matches` rule has a large number of possible matches (common when validating to make sure that links point to a valid route or that images point to a file that exists) the error message can be extremely verbose. This PR makes it so that when the number of possible values exceeds eight, the validator only lists the first eight explicitly and then indicates how many more potential values are available. This ensures that users don't get giant error messages with hundreds of possible values. 

The new error message looks like this:

```
Attribute 'jawn' must match one of ["a","b","c","d","e","f","g","h", ... 4 more]. Got 'cat' instead.
```

This approach loosely imitates the way that the node.js repl displays long arrays that are printed with `console.log`.