### PR TITLE
Introduces slots

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
       "runtimeArgs": ["-r", "ts-eager/register"],
       "console": "integratedTerminal",
       "program": "${workspaceFolder}/spec/marktest/index.ts",
-      "cwd": "${workspaceFolder}/spec/marktest",
+      "cwd": "${workspaceFolder}",
       "args": ["${file}:${lineNumber}"]
     }
   ]

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ import transforms from './src/transforms';
 import { parseTags, isPromise } from './src/utils';
 import validator from './src/validator';
 
-import type { Node } from './src/types';
+import type { Node, ParserArgs } from './src/types';
 import type Token from 'markdown-it/lib/token';
 import type { Config, RenderableTreeNode, ValidateError } from './src/types';
 
@@ -39,9 +39,12 @@ function mergeConfig(config: Config = {}): Config {
   };
 }
 
-export function parse(content: string | Token[], file?: string): Node {
+export function parse(
+  content: string | Token[],
+  args?: string | ParserArgs
+): Node {
   if (typeof content === 'string') content = tokenizer.tokenize(content);
-  return parser(content, file);
+  return parser(content, args);
 }
 
 export function resolve<C extends Config = Config>(

--- a/spec/marktest/index.ts
+++ b/spec/marktest/index.ts
@@ -23,9 +23,9 @@ const tokenizer = new markdoc.Tokenizer({
   allowComments: true,
 });
 
-function parse(content: string, file?: string) {
+function parse(content: string, slots?: boolean, file?: string) {
   const tokens = tokenizer.tokenize(content);
-  return markdoc.parse(tokens, file);
+  return markdoc.parse(tokens, { file, slots });
 }
 
 function stripLines(object) {
@@ -36,7 +36,7 @@ function stripLines(object) {
 function render(code, config, dynamic) {
   const partials = {};
   for (const [file, content] of Object.entries(config.partials ?? {}))
-    partials[file] = parse(content as string, file);
+    partials[file] = parse(content as string, false, file);
 
   const { react, reactStatic } = markdoc.renderers;
   const transformed = markdoc.transform(code, { ...config, partials });
@@ -105,7 +105,7 @@ function formatValidation(filename, test, validation) {
 
   let exitCode = 0;
   for (const test of tests) {
-    const code = parse(test.code || '');
+    const code = parse(test.code || '', test.slots);
 
     const { start, end } = test.$$lines;
     if (line && (Number(line) - 1 < start || Number(line) - 1 > end)) continue;

--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -1592,3 +1592,197 @@
   code: |
     {% foo bar="this is a test of \"quoted\" strings" /%}
   expected: <article><foo bar="this is a test of &quot;quoted&quot; strings"></foo></article>
+
+- name: Basic slot
+  config:
+    tags:
+      foo:
+        render: foo
+        slots:
+          bar: {}
+  code: |
+    {% foo %}
+      {% slot "bar" %}
+      This is a test
+      {% /slot %}
+    {% /foo %}
+  slots: true
+  expected:
+    - tag: foo
+      attributes:
+        bar:
+          - tag: p
+            children:
+              - This is a test
+
+- name: Tag with multiple slots and additional content
+  config:
+    tags:
+      foo:
+        render: foo
+        attributes:
+          qux:
+            type: String
+        slots:
+          bar: {}
+          baz: {}
+  code: |
+    {% foo qux="test" %}
+      {% slot "bar" %}
+      This is a test
+      {% /slot %}
+
+      {% slot "baz" %}
+      This is **another** test
+      {% /slot %}
+
+      This is additional content
+    {% /foo %}
+  slots: true
+  expected:
+    - tag: foo
+      attributes:
+        qux: test
+        bar:
+          - tag: p
+            children:
+              - This is a test
+        baz:
+          - tag: p
+            children:
+              - 'This is '
+              - tag: strong
+                children: [another]
+              - ' test'
+      children:
+        - tag: p
+          children:
+            - This is additional content
+
+- name: User slot tag when slots are disabled
+  config:
+    tags:
+      slot:
+        render: foo
+  code: |
+    {% slot %}
+    bar
+    {% /slot %}
+  expected:
+    - tag: foo
+      children:
+        - tag: p
+          children: [bar]
+
+- name: Handling slots that are missing a name
+  config:
+    tags:
+      foo:
+        render: foo
+        attributes:
+          bar:
+            type: Node
+  code: |
+    {% foo %}
+      {% slot %}
+      This is a test
+      {% /slot %}
+    {% /foo %}
+  slots: true
+  expectedError: "Missing required attribute: 'primary'"
+  expected:
+    - tag: foo
+      children: [null]
+
+- name: Handling slots with invalid name
+  config:
+    tags:
+      foo:
+        render: foo
+        attributes:
+          bar:
+            type: Node
+  code: |
+    {% foo %}
+      {% slot 1 %}
+      This is a test
+      {% /slot %}
+    {% /foo %}
+  slots: true
+  expectedError: "Attribute 'primary' must be type of 'String'"
+  expected:
+    - tag: foo
+      children: [null]
+
+- name: Validating required slot
+  config:
+    tags:
+      foo:
+        render: foo
+        slots:
+          bar:
+            required: true
+  code: |
+    {% foo %}
+    {% /foo %}
+  slots: true
+  expectedError: "Missing required slot: 'bar'"
+  expected:
+    - tag: foo
+
+- name: Handling invalid slot
+  config:
+    tags:
+      foo:
+        render: foo
+  code: |
+    {% foo %}
+      {% slot "bar" %}
+      This is a test
+      {% /slot %}
+    {% /foo %}
+  slots: true
+  expectedError: "Invalid slot: 'bar'"
+  expected:
+    - tag: foo
+
+- name: Handling overlapping slot and attribute
+  config:
+    tags:
+      foo:
+        render: foo
+        attributes:
+          bar:
+            type: String
+        slots:
+          bar: {}
+  code: |
+    {% foo bar="test" %}
+    {% /foo %}
+
+    {% foo bar="test" %}
+      {% slot "bar" %}
+      test
+      {% /slot %}
+    {% /foo %}
+
+    {% foo %}
+      {% slot "bar" %}
+      test
+      {% /slot %}
+    {% /foo %}
+  slots: true
+  expected:
+    - tag: foo
+      attributes:
+        bar: 'test'
+    - tag: foo
+      attributes:
+        bar:
+          - tag: p
+            children: [test]
+    - tag: foo
+      attributes:
+        bar:
+          - tag: p
+            children: [test]

--- a/src/ast/node.test.ts
+++ b/src/ast/node.test.ts
@@ -28,6 +28,53 @@ describe('Node object', function () {
       expect(output.length).toEqual(6);
     });
   });
+
+  it('without slots', function () {
+    const example = `
+{% example %}
+# bar
+
+baz
+{% /example %}
+    `;
+
+    const ast = markdoc.parse(example, { slots: true });
+    const iter = Array.from(ast.walk());
+    expect(iter.map((n) => n.tag ?? n.type)).toEqual([
+      'example',
+      'heading',
+      'inline',
+      'text',
+      'paragraph',
+      'inline',
+      'text',
+    ]);
+  });
+
+  it('with slots', function () {
+    const example = `
+{% example %}
+# bar
+
+{% slot "foo" %}
+baz
+{% /slot %}
+{% /example %}
+    `;
+
+    const ast = markdoc.parse(example, { slots: true });
+    const iter = Array.from(ast.walk());
+    expect(iter.map((n) => n.tag ?? n.type)).toEqual([
+      'example',
+      'slot',
+      'paragraph',
+      'inline',
+      'text',
+      'heading',
+      'inline',
+      'text',
+    ]);
+  });
 });
 
 describe('transform', function () {

--- a/src/ast/node.ts
+++ b/src/ast/node.ts
@@ -17,6 +17,7 @@ export default class Node implements AstType {
   readonly $$mdtype = 'Node';
 
   attributes: Record<string, any>;
+  slots: Record<string, Node>;
   children: Node[];
   errors: ValidationError[] = [];
   lines: number[] = [];
@@ -38,9 +39,15 @@ export default class Node implements AstType {
     this.type = type;
     this.tag = tag;
     this.annotations = [];
+    this.slots = {};
   }
 
   *walk(): Generator<Node, void, unknown> {
+    for (const slot of Object.values(this.slots)) {
+      yield slot;
+      yield* slot.walk();
+    }
+
     for (const child of this.children) {
       yield child;
       yield* child.walk();

--- a/src/ast/node.ts
+++ b/src/ast/node.ts
@@ -43,12 +43,7 @@ export default class Node implements AstType {
   }
 
   *walk(): Generator<Node, void, unknown> {
-    for (const slot of Object.values(this.slots)) {
-      yield slot;
-      yield* slot.walk();
-    }
-
-    for (const child of this.children) {
+    for (const child of [...Object.values(this.slots), ...this.children]) {
       yield child;
       yield* child.walk();
     }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -9,11 +9,49 @@ describe('Markdown parser', function () {
   const fence = '```';
   const tokenizer = new Tokenizer({ allowComments: true });
 
-  function convert(example) {
+  function convert(example, options?) {
     const content = example.replace(/\n\s+/gm, '\n').trim();
     const tokens = tokenizer.tokenize(content);
-    return parser(tokens);
+    return parser(tokens, options);
   }
+
+  describe('handling options', function () {
+    it('no args', function () {
+      const example = convert(`# This is a test`);
+      expect(example.children[0]).toDeepEqual({
+        ...any(),
+        type: 'heading',
+        location: {
+          ...any(),
+          file: undefined,
+        },
+      });
+    });
+
+    it('filename as string', function () {
+      const example = convert(`# This is a test`, 'foo.md');
+      expect(example.children[0]).toDeepEqual({
+        ...any(),
+        type: 'heading',
+        location: {
+          ...any(),
+          file: 'foo.md',
+        },
+      });
+    });
+
+    it('filename as property', function () {
+      const example = convert(`# This is a test`, { file: 'foo.md' });
+      expect(example.children[0]).toDeepEqual({
+        ...any(),
+        type: 'heading',
+        location: {
+          ...any(),
+          file: 'foo.md',
+        },
+      });
+    });
+  });
 
   describe('handling frontmatter', function () {
     it('simple frontmatter', function () {

--- a/src/tags/index.ts
+++ b/src/tags/index.ts
@@ -1,10 +1,12 @@
 import { tagIf, tagElse } from './conditional';
 import { partial } from './partial';
 import { table } from './table';
+import { slot } from './slot';
 
 export default {
   if: tagIf,
   else: tagElse,
   partial,
   table,
+  slot,
 };

--- a/src/tags/index.ts
+++ b/src/tags/index.ts
@@ -4,9 +4,9 @@ import { table } from './table';
 import { slot } from './slot';
 
 export default {
-  if: tagIf,
   else: tagElse,
+  if: tagIf,
   partial,
-  table,
   slot,
+  table,
 };

--- a/src/tags/slot.ts
+++ b/src/tags/slot.ts
@@ -1,0 +1,7 @@
+import type { Schema } from '../types';
+
+export const slot: Schema = {
+  attributes: {
+    primary: { type: String, required: true },
+  },
+};

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -47,6 +47,13 @@ export default {
       output[name] = value;
     }
 
+    if (schema.slots) {
+      for (const [key, slot] of Object.entries(schema.slots)) {
+        const name = typeof slot.render === 'string' ? slot.render : key;
+        if (node.slots[key]) output[name] = this.node(node.slots[key], config);
+      }
+    }
+
     return output;
   },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export type Schema<C extends Config = Config, R = string> = {
   render?: R;
   children?: string[];
   attributes?: Record<string, SchemaAttribute>;
+  slots?: Record<string, SchemaSlot>;
   selfClosing?: boolean;
   inline?: boolean;
   transform?(node: Node, config: C): MaybePromise<RenderableTreeNodes>;
@@ -118,6 +119,11 @@ export type SchemaAttribute = {
 };
 
 export type SchemaMatches = RegExp | string[] | null;
+
+export type SchemaSlot = {
+  render?: boolean | string;
+  required?: boolean;
+};
 
 export interface Transformer {
   findSchema(node: Node, config: Config): Schema | undefined;
@@ -154,3 +160,8 @@ export type ValidationType =
   | 'Array';
 
 export type Value = AstType | Scalar;
+
+export type ParserArgs = {
+  file?: string;
+  slots?: boolean;
+};

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -164,6 +164,16 @@ export default function validator(node: Node, config: Config) {
     ...schema.attributes,
   };
 
+  for (const key of Object.keys(node.slots)) {
+    const slot = schema.slots?.[key];
+    if (!slot)
+      errors.push({
+        id: 'slot-undefined',
+        level: 'error',
+        message: `Invalid slot: '${key}'`,
+      });
+  }
+
   for (let [key, value] of Object.entries(node.attributes)) {
     const attrib = attributes[key];
 
@@ -247,6 +257,15 @@ export default function validator(node: Node, config: Config) {
         level: 'error',
         message: `Missing required attribute: '${key}'`,
       });
+
+  if (schema.slots)
+    for (const [key, { required }] of Object.entries(schema.slots))
+      if (required && node.slots[key] === undefined)
+        errors.push({
+          id: 'slot-missing-required',
+          level: 'error',
+          message: `Missing required slot: '${key}'`,
+        });
 
   for (const { type } of node.children) {
     if (schema.children && type !== 'error' && !schema.children.includes(type))


### PR DESCRIPTION
This PR implements the [slots proposal](https://github.com/markdoc/markdoc/discussions/342) in Markdoc. Slots make it possible for a custom tag to accept multiple sets of children, providing an to attributes that is suitable for cases where you want to accept arbitrary Markdoc content instead of a conventional attribute type.

- When slots are enabled, the parser automatically takes content that is wrapped inside of a `slot` tag and adds it to the `Node` object's `slots` property instead of the `Node`'s children.
- The AST `Node` class stores slots in a `slots` property on the `Node` object
  - The `Node.walk` iterator function recursively yields the slots and their children before yielding the `Node`'s children
- The top-level `parse` function now accepts an object with parse settings, which takes the shape `{file: string, slots: boolean}`
  - Special-case handling for slots during parsing only occurs when the value of the `slots` configuration property is `true`, otherwise each `slot` in a document is treated like a conventional tag named `slot`.
  - For backwards compatibility, the settings parameter for the `parse` function can also be a string by itself, which is treated as `{file: string}`.
  - Test cases to validate settings behavior are added in `parser.test.ts`
- The Marktest testing tool automatically enables slots when the test case has `slots: true` in the top-level test object
  - Adds a bunch of Marktest cases to test verify that the slots functionality is working as expected
- Schema types were tweaked to support declaring slots inside of tag and node definitions
  - A slot is declared a bit like an attribute, the user can specify whether it is required and whether it renders
  - The validator explicitly checks to make sure that required slots are fulfilled and displays a new `slot-missing-required` error when one is missing
  - The validator explicitly checks to make sure that there are no extra slots added to content that are not supported in the schema and shows a `slot-undefined` error when one is detected
- A built-in `slot` tag is defined in the schema
  - The slot tag must have a primary attribute with a `String` type value  that reflects the slot's name
- The `trasnsformer.attributes` function was updated to process slots on a given `Node` instance after processing attributes. It iterates over slots that are declared in the schema for the `Node` instance, renders each `slot` node, and adds them to the rendered attribute object