### PR TITLE
Correctly handle numbers for ordered list items

### DIFF
--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -15,6 +15,8 @@
     3. baz
   expected:
     - tag: ol
+      attributes:
+        start: '1'
       children:
         - tag: li
           children: [foo]

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -421,9 +421,9 @@ Yes!
 - [Install Markdoc](/docs/getting-started)
 - [Try it out online](/sandbox)
 
-1. One {% align="left" %}
-2. Two
-3. Three
+3. One {% align="left" %}
+4. Two
+5. Three
 
 - A
 - B
@@ -433,9 +433,9 @@ Yes!
 - [Install Markdoc](/docs/getting-started)
 - [Try it out online](/sandbox)
 
-1. One {% align="left" %}
-1. Two
-1. Three
+3. One {% align="left" %}
+4. Two
+5. Three
 
 - A
 - B
@@ -454,12 +454,12 @@ Yes!
 * qux
 
 
-1) foo
-2) bar
-3) baz
-1. foo
-2. bar
-3. baz
+7) foo
+8) bar
+9) baz
+3. foo
+4. bar
+5. baz
 `;
     const expected = `
 - foo
@@ -468,13 +468,13 @@ Yes!
 * baz
 * qux
 
-1) foo
-1) bar
-1) baz
+7) foo
+8) bar
+9) baz
 
-1. foo
-1. bar
-1. baz
+3. foo
+4. bar
+5. baz
 `;
     check(source, expected);
     stable(expected);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -287,10 +287,10 @@ function* formatNode(n: Node, o: Options = {}) {
       break;
     }
     case 'list': {
-      const prefix = n.attributes.ordered
-        ? `1${n.attributes.marker ?? OL}`
-        : n.attributes.marker ?? UL;
       for (const child of n.children) {
+        const prefix = n.attributes.ordered
+          ? `${child.attributes.value ?? '1'}${n.attributes.marker ?? OL}`
+          : n.attributes.marker ?? UL;
         const d = format(child, increment(no, prefix.length + 1)).trim();
         yield NL + indent + prefix + ' ' + d;
       }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -115,6 +115,26 @@ describe('Markdown parser', function () {
       expect(ordered.children[0].attributes.ordered).toEqual(true);
     });
 
+    it('for list item', function () {
+      const unordered = convert(`
+      * Example 1
+      * Example 2
+      * Example 3
+      `);
+
+      const numbered = convert(`
+      3. Example 1
+      4. Example 2
+      5. Example 3
+      `);
+
+      const values = (list) =>
+        list.children[0].children.map((child) => child.attributes.value);
+
+      expect(values(unordered)).toDeepEqual([undefined, undefined, undefined]);
+      expect(values(numbered)).toDeepEqual(['3', '4', '5']);
+    });
+
     it('for link with one word', function () {
       const document = convert(`
       [foo](/bar)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,6 +35,8 @@ function handleAttrs(token: Token, type: string) {
         ordered: token.type.startsWith('ordered'),
         marker: token.markup,
       };
+    case 'item':
+      return token.info ? { value: token.info } : {};
     case 'link': {
       const attrs = Object.fromEntries(token.attrs);
       return attrs.title


### PR DESCRIPTION
This  PR addresses issue #371, ensuring that ordered lists are rendered with a `start` attribute that reflects the number of the first item in the list. This is consistent with the behavior described in the CommonMark specification. The PR also introduces a new `value` attribute on list item AST nodes that captures the list number used for each ordered list item.

- Parser modifications
  - Modifies the parser so that the leading symbol for a list item is assigned to the `value` property on the AST node
  - Adds a parser Jasmine test case to ensure that ordered and unordered lists have the correct values for the `value` attribute
- Schema modifications
  - Modifies the schema to add the new `value` attribute to the list item node
  - Modifies the `list` node transform function so that when the list is ordered it walks the children, obtains the `value` attribute of the first child, and uses that as the `start` value passed into the render tree
  - Modifies a marktest case with ordered list items in order to reflect the presence of the `start` attribute in the render tree
- Formatter modifications
  - Modifies the formatter so that it computes the list prefix for each individual item, using the `value` attribute for ordered list items and falling back to `"1"` when it is not present
  - Modifies the formatter test cases so that they verify that the ordered list numbers are preserved

Closes https://github.com/markdoc/markdoc/issues/371