### PR TITLE
Preserves em and strong markers in the AST

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -176,6 +176,23 @@ paragraph 2
     stable(source);
   });
 
+  it('emphasis marks', () => {
+    const examples = [
+      '*foo* bar baz',
+      '**foo** bar baz',
+      '_foo_ bar baz',
+      '__foo__ bar baz',
+      'foo*bar*baz',
+      'foo_bar_baz',
+    ];
+
+    examples.forEach((example) => {
+      const ast = Markdoc.parse(example.trim());
+      const out = Markdoc.format(ast);
+      expect(example).toEqual(out.trim());
+    });
+  });
+
   it('complex attributes', () => {
     const source = `{% if $gates["<string_key>"].test["@var"] id="id with space" class="class with space" /%}`;
     const expected = `{% if

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -305,15 +305,15 @@ function* formatNode(n: Node, o: Options = {}) {
       break;
     }
     case 'strong': {
-      yield '**';
+      yield n.attributes.marker ?? '**';
       yield* formatInline(formatChildren(n, no));
-      yield '**';
+      yield n.attributes.marker ?? '**';
       break;
     }
     case 'em': {
-      yield '_';
+      yield n.attributes.marker ?? '*';
       yield* formatInline(formatChildren(n, no));
-      yield '_';
+      yield n.attributes.marker ?? '*';
       break;
     }
     case 'code': {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -93,6 +93,29 @@ describe('Markdown parser', function () {
   });
 
   describe('handling attributes', function () {
+    it('for emphasis', function () {
+      const items = (doc, n = 0) =>
+        doc.children[0].children[0].children[n].attributes.marker;
+
+      const example1 = convert(`a*b*c`);
+      expect(items(example1, 1)).toEqual('*');
+
+      const example1a = convert(`a**b**c`);
+      expect(items(example1a, 1)).toEqual('**');
+
+      const example2 = convert(`_foo_ bar`);
+      expect(items(example2)).toEqual('_');
+
+      const example2a = convert(`__foo__ bar`);
+      expect(items(example2a)).toEqual('__');
+
+      const example3 = convert(`foo *bar* baz`);
+      expect(items(example3, 1)).toEqual('*');
+
+      const example3a = convert(`foo **bar** baz`);
+      expect(items(example3a, 1)).toEqual('**');
+    });
+
     it('for heading', function () {
       const document = convert(`# Sample Heading`);
       expect(document.children[0].attributes).toDeepEqual({ level: 1 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -47,6 +47,9 @@ function handleAttrs(token: Token, type: string) {
         ? { alt: token.content, src: attrs.src, title: attrs.title }
         : { alt: token.content, src: attrs.src };
     }
+    case 'em':
+    case 'strong':
+      return { marker: token.markup };
     case 'text':
     case 'code':
     case 'comment':

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -167,11 +167,17 @@ export const thead: Schema = {
 export const strong: Schema = {
   render: 'strong',
   children: ['em', 's', 'link', 'code', 'text', 'tag'],
+  attributes: {
+    marker: { type: String, render: false },
+  },
 };
 
 export const em: Schema = {
   render: 'em',
   children: ['strong', 's', 'link', 'code', 'text', 'tag'],
+  attributes: {
+    marker: { type: String, render: false },
+  },
 };
 
 export const s: Schema = {


### PR DESCRIPTION
This PR addresses issue #369. It makes the parser capture the actual symbols used for `em` and `strong` nodes and preserve that information in the AST so that it can be used in the formatter to reproduce the content accurately.

- Parser modifications
  - Modifies the parser to capture the emphasis markup for `em` and `strong` nodes and apply it to a node attribute called `marker`
  - Adds a Jasmine test case to ensure that emphasis nodes get the proper `marker` attribute
- Schema modifications
  - Adds a non-rendering `marker` attribute to the `strong` and `em` node schemas
- Formatter modifications
  - Modifies the formatter so that it renders `em `and `strong` nodes using the original emphasis marker from the source content and falls back on `*` or `**` when not available
  - Adds a Jasmine test case to the formatter to ensure that the output matches the source

Closes https://github.com/markdoc/markdoc/issues/369