### PR TITLE
Store `start` on ordered lists rather than `value` on ordered list items

### DIFF
--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -15,8 +15,23 @@
     3. baz
   expected:
     - tag: ol
+      children:
+        - tag: li
+          children: [foo]
+        - tag: li
+          children: [bar]
+        - tag: li
+          children: [baz]
+
+- name: Ordered list with start
+  code: |
+    2. foo
+    3. bar
+    4. baz
+  expected:
+    - tag: ol
       attributes:
-        start: '1'
+        start: 2
       children:
         - tag: li
           children: [foo]

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -451,8 +451,8 @@ Yes!
 - [Try it out online](/sandbox)
 
 3. One {% align="left" %}
-4. Two
-5. Three
+1. Two
+1. Three
 
 - A
 - B
@@ -472,11 +472,14 @@ Yes!
 
 
 7) foo
-8) bar
-9) baz
+1) bar
+1) baz
 3. foo
-4. bar
-5. baz
+1. bar
+1. baz
+1) foo
+4) bar
+9) baz
 `;
     const expected = `
 - foo
@@ -486,12 +489,16 @@ Yes!
 * qux
 
 7) foo
-8) bar
-9) baz
+1) bar
+1) baz
 
 3. foo
-4. bar
-5. baz
+1. bar
+1. baz
+
+1) foo
+1) bar
+1) baz
 `;
     check(source, expected);
     stable(expected);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -287,11 +287,16 @@ function* formatNode(n: Node, o: Options = {}) {
       break;
     }
     case 'list': {
-      for (const child of n.children) {
+      for (let i = 0; i < n.children.length; i++) {
         const prefix = n.attributes.ordered
-          ? `${child.attributes.value ?? '1'}${n.attributes.marker ?? OL}`
+          ? `${i === 0 ? n.attributes.start ?? '1' : '1'}${
+              n.attributes.marker ?? OL
+            }`
           : n.attributes.marker ?? UL;
-        const d = format(child, increment(no, prefix.length + 1)).trim();
+        const d = format(
+          n.children[i],
+          increment(no, prefix.length + 1)
+        ).trim();
         yield NL + indent + prefix + ' ' + d;
       }
       yield NL;

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -138,7 +138,7 @@ describe('Markdown parser', function () {
       expect(ordered.children[0].attributes.ordered).toEqual(true);
     });
 
-    it('for list item', function () {
+    it('for ordered list start', function () {
       const unordered = convert(`
       * Example 1
       * Example 2
@@ -151,11 +151,17 @@ describe('Markdown parser', function () {
       5. Example 3
       `);
 
-      const values = (list) =>
-        list.children[0].children.map((child) => child.attributes.value);
+      const numberedStartAtOne = convert(`
+      1. Example 1
+      4. Example 2
+      5. Example 3
+      `);
 
-      expect(values(unordered)).toDeepEqual([undefined, undefined, undefined]);
-      expect(values(numbered)).toDeepEqual(['3', '4', '5']);
+      const start = (list) => list.children[0].attributes.start;
+
+      expect(start(unordered)).toEqual(undefined);
+      expect(start(numbered)).toEqual(3);
+      expect(start(numberedStartAtOne)).toEqual(undefined);
     });
 
     it('for link with one word', function () {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -30,13 +30,13 @@ function handleAttrs(token: Token, type: string) {
   switch (type) {
     case 'heading':
       return { level: Number(token.tag.replace('h', '')) };
-    case 'list':
-      return {
-        ordered: token.type.startsWith('ordered'),
-        marker: token.markup,
-      };
-    case 'item':
-      return token.info ? { value: token.info } : {};
+    case 'list': {
+      const attrs = token.attrs ? Object.fromEntries(token.attrs) : undefined;
+      const ordered = token.type.startsWith('ordered');
+      return ordered && attrs?.start
+        ? { ordered: true, start: attrs.start, marker: token.markup }
+        : { ordered, marker: token.markup };
+    }
     case 'link': {
       const attrs = Object.fromEntries(token.attrs);
       return attrs.title

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,4 @@
-import type { Node, Schema } from './types';
+import type { Schema } from './types';
 import Tag from './tag';
 
 export const document: Schema = {
@@ -95,29 +95,19 @@ export const item: Schema = {
     'list',
     'hr',
   ],
-  attributes: {
-    value: { type: String, render: false },
-  },
 };
-
-function findListStart(node: Node) {
-  if (node.attributes.ordered)
-    for (const child of node.walk())
-      if (child.type === 'item') return child.attributes.value;
-}
 
 export const list: Schema = {
   children: ['item'],
   attributes: {
     ordered: { type: Boolean, render: false, required: true },
+    start: { type: Number },
     marker: { type: String, render: false },
   },
   transform(node, config) {
-    const start = findListStart(node);
-    const attrs = node.transformAttributes(config);
     return new Tag(
       node.attributes.ordered ? 'ol' : 'ul',
-      start ? { start, ...attrs } : attrs,
+      node.transformAttributes(config),
       node.transformChildren(config)
     );
   },


### PR DESCRIPTION
The way that #371 was fixed in #372 somewhat surprised me because markdown-it returns the start as an attribute on the ordered list so it can be an attribute directly on the list rather than as a new attribute on list items and adding the attribute to the list in a transform. This PR implements that approach of `start` as an attribute on ordered lists rather than `value` on ordered list items.

I've also changed the formatter to not use the number on list items so it only uses the start for the first item and `1` for all other items. For example, for this Markdoc:

```md
2. a
7. b
20. c
```

The formatter in this PR outputs this:

```md
2. a
1. b
1. c
```

Not preserving the numbers of the non-first items aligns with what other formatters do. For example, for the input above, Prettier outputs this:

```md
2. a
3. b
4. c
```

but for this:

```md
2. a
1. b
4. c
```

Prettier outputs:

```md
2. a
1. b
1. c
```

Prettier's rule is "incrementing unless the number in the second list item is 1 then use 1 for everything except for the first which uses the start." Personally, I liked how Markdoc's formatter before #372 always outputted the diff-friendly style of always `1` so I've kept it like that rather than sometimes doing incrementing.