### PR TITLE
Makes parser correctly identify unmatched opening tags

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -739,4 +739,34 @@ describe('Markdown parser', function () {
       ],
     });
   });
+
+  describe('handles structural errors correctly', function () {
+    it('with unmatched closing tag', function () {
+      const example = convert(`
+    {% foo %}
+    Test
+    {% /bar %}
+    `);
+
+      expect(example.children[0].errors[0].id).toEqual('missing-closing');
+    });
+
+    it('missing opening', function () {
+      const example = convert(`
+      This a test
+      {% /foo %}
+      `);
+
+      expect(example.children[1].errors[0].id).toEqual('missing-opening');
+    });
+
+    it('with missing closing tag', function () {
+      const example = convert(`
+    {% foo %}
+    Test
+    `);
+
+      expect(example.children[0].errors[0].id).toEqual('missing-closing');
+    });
+  });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -126,7 +126,7 @@ function handleToken(
   }
 
   if (token.nesting < 0) {
-    if (parent.type === typeName) {
+    if (parent.type === typeName && parent.tag === tag) {
       if (parent.lines && token.map) parent.lines.push(...token.map);
       return nodes.pop();
     }


### PR DESCRIPTION
When the parser attempts to determine if a closing token matches the latest parent on the stack, it only checks the node type and does not check the tag name. Early versions of markdoc used to include the tag name in the type attribute, but this condition wasn't updated when the tag became its own property.

This PR addresses issue #375 by updating the condition so that it checks to make sure that the `tag` name matches the value of `parent.tag`. This will make the check work as expected for opening and closing tags. For non-tag nodes, the value of `tag` and `parent.tag` should both be `undefined`, so this approach should work as expected for all node types.

In addition to fixing the issue, this PR also adds test cases to ensure that the structural errors are added to the AST for mismatched opening and closing tags, missing closing tags, and missing opening tags.