### PR TITLE
Adds validate function to attributes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,7 @@ export type SchemaAttribute = {
   default?: any;
   required?: boolean;
   matches?: SchemaMatches | ((config: Config) => SchemaMatches);
+  validate?(value: any, config: Config): ValidationError[];
   errorLevel?: ValidationError['level'];
 };
 

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -289,6 +289,44 @@ bar
   });
 
   describe('attribute validation', () => {
+    describe('with a validate function', () => {
+      it('using simple conditional', () => {
+        const schema = {
+          tags: {
+            foo: {
+              attributes: {
+                bar: {
+                  type: Number,
+                  validate(value, _config) {
+                    return value > 10
+                      ? []
+                      : [
+                          {
+                            id: 'attribute-should-be-greater-than-ten',
+                            message:
+                              'Attribute "bar" must have value greater than 10.',
+                          },
+                        ];
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        expect(validate(`{% foo bar=20 /%}`, schema)).toEqual([]);
+        expect(validate(`{% foo bar=5 /%}`, schema)).toDeepEqualSubset([
+          {
+            type: 'tag',
+            error: {
+              id: 'attribute-should-be-greater-than-ten',
+              message: 'Attribute "bar" must have value greater than 10.',
+            },
+          },
+        ]);
+      });
+    });
+
     it('should return error on failure to match array', () => {
       const example = '{% foo jawn="cat" /%}';
       const schema = {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -248,6 +248,11 @@ export default function validator(node: Node, config: Config) {
         level: errorLevel || 'error',
         message: `Attribute '${key}' must match ${matches}. Got '${value}' instead.`,
       });
+
+    if (typeof attrib.validate === 'function') {
+      const attribErrors = attrib.validate(value, config);
+      if (Array.isArray(attribErrors)) errors.push(...attribErrors);
+    }
   }
 
   for (const [key, { required }] of Object.entries(attributes))


### PR DESCRIPTION
This PR addresses issue #379. It adds support for writing a custom `validate` function for an individual schema attribute. The function can return an arbitrary number of Markdoc validation error objects.

After weighing the tradeoffs, I decided not to support async functions for this case because it would require us to collect and await all of them before continuing, introducing more complexity. We can still potentially add support for that in the future if there's sufficient demand.