### PR TITLE
Adds description property to schema types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,7 @@ export type Schema<C extends Config = Config, R = string> = {
   inline?: boolean;
   transform?(node: Node, config: C): MaybePromise<RenderableTreeNodes>;
   validate?(node: Node, config: C): MaybePromise<ValidationError[]>;
+  description?: string;
 };
 
 export type SchemaAttribute = {
@@ -116,6 +117,7 @@ export type SchemaAttribute = {
   required?: boolean;
   matches?: SchemaMatches | ((config: Config) => SchemaMatches);
   errorLevel?: ValidationError['level'];
+  description?: string;
 };
 
 export type SchemaMatches = RegExp | string[] | null;


### PR DESCRIPTION
This is a really minor tweak to the schema types to formally add the `description?: string` property. We use this convention internally and I want to standardize it in the broader ecosystem so that we can make the language server take advantage of it when present.