### PR TITLE
Adds validation message for duplicate attributes

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -810,6 +810,93 @@ describe('Markdown parser', function () {
     });
   });
 
+  it('displays error for annotations in a fence', function () {
+    const example = convert(`
+    ~~~
+    test
+    {% #foo %}
+    test
+    ~~~
+    `);
+
+    expect(Object.values(example.annotations).length).toEqual(0);
+    expect(example.children[0].errors[0]?.id).toEqual('no-inline-annotations');
+  });
+
+  it('correctly identifies inlines', function () {
+    const example = convert(`
+    # This is a test
+
+    {% foo %}
+    Another {% bar %}test{% /bar %} test
+    {% /foo %}
+
+    * bar
+    `);
+
+    expect(example).toDeepEqualSubset({
+      type: 'document',
+      inline: false,
+      children: [
+        {
+          type: 'heading',
+          inline: false,
+          children: [
+            {
+              type: 'inline',
+              inline: false,
+              children: [{ type: 'text', inline: true }],
+            },
+          ],
+        },
+        {
+          type: 'tag',
+          tag: 'foo',
+          inline: false,
+          children: [
+            {
+              type: 'paragraph',
+              inline: false,
+              children: [
+                {
+                  type: 'inline',
+                  inline: false,
+                  children: [
+                    { type: 'text', inline: true },
+                    {
+                      type: 'tag',
+                      tag: 'bar',
+                      inline: true,
+                      children: [{ type: 'text', inline: true }],
+                    },
+                    { type: 'text', inline: true },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'list',
+          inline: false,
+          children: [
+            {
+              type: 'item',
+              inline: false,
+              children: [
+                {
+                  type: 'inline',
+                  inline: false,
+                  children: [{ type: 'text', inline: true }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   describe('handles structural errors correctly', function () {
     it('with unmatched closing tag', function () {
       const example = convert(`

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -740,6 +740,76 @@ describe('Markdown parser', function () {
     });
   });
 
+  describe('handles attribute errors correctly', function () {
+    it('with error for duplicate attributes', function () {
+      const example = convert(`{% foo bar=1 bar=2 bar=3 bar=4 /%}`);
+      expect(example.children[0].errors.length).toBe(3);
+      expect(example).toDeepEqualSubset({
+        type: 'document',
+        children: [
+          {
+            tag: 'foo',
+            errors: [
+              { id: 'duplicate-attribute' },
+              { id: 'duplicate-attribute' },
+              { id: 'duplicate-attribute' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('with error for duplicate ids', function () {
+      const example = convert(`{% foo #bar #baz #qux /%}`);
+      expect(example.children[0].errors.length).toBe(2);
+      expect(example).toDeepEqualSubset({
+        type: 'document',
+        children: [
+          {
+            tag: 'foo',
+            errors: [
+              { id: 'duplicate-attribute' },
+              { id: 'duplicate-attribute' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('with annotation values', function () {
+      const example = convert(`testing {% foo=1 foo=2 %}`);
+      expect(example.children[0].errors.length).toBe(1);
+      expect(example).toDeepEqualSubset({
+        type: 'document',
+        children: [
+          {
+            type: 'paragraph',
+            errors: [{ id: 'duplicate-attribute' }],
+          },
+        ],
+      });
+    });
+
+    it('across annotations on the same node', function () {
+      const example = convert(`testing {% foo=1 %} another test {% foo=1 %}`);
+      expect(example.children[0].errors.length).toBe(1);
+      expect(example).toDeepEqualSubset({
+        type: 'document',
+        children: [
+          {
+            type: 'paragraph',
+            errors: [{ id: 'duplicate-attribute' }],
+          },
+        ],
+      });
+    });
+
+    it('with no error for multiple classes', function () {
+      const example = convert(`{% foo .bar .baz .qux /%}`);
+      expect(example.children[0].errors.length).toBe(0);
+    });
+  });
+
   describe('handles structural errors correctly', function () {
     it('with unmatched closing tag', function () {
       const example = convert(`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -180,7 +180,7 @@ function handleToken(
 
   if (!Array.isArray(token.children)) return;
 
-  inlineParent = parent;
+  if (node.type === 'inline') inlineParent = parent;
 
   nodes.push(node);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,8 +19,15 @@ function annotate(node: Node, attributes: AttributeValue[]) {
     node.annotations.push(attribute);
 
     const { name, value, type } = attribute;
-    if (type === 'attribute') node.attributes[name] = value;
-    else if (type === 'class')
+    if (type === 'attribute') {
+      if (node.attributes[name] !== undefined)
+        node.errors.push({
+          id: 'duplicate-attribute',
+          level: 'warning',
+          message: `Attribute '${name}' already set`,
+        });
+      node.attributes[name] = value;
+    } else if (type === 'class')
       if (node.attributes.class) node.attributes.class[name] = value;
       else node.attributes.class = { [name]: value };
   }


### PR DESCRIPTION
This PR addresses issue #391. It modifies the `annotate` function in the parser so that it appends an error to the node's `errors` array when it detects a duplicate attribute. This does not actually change the rendering behavior of duplicate attributes—it still gives precedence to the last one added. I also added test cases to verify that this works as expected for multiple attributes in the same tag, multiple attributes in the same annotation, and multiple attributes across separate annotations on the same document node. 

Closes #391 
