### PR TITLE
Properly handle annotations in fenced code blocks

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -740,6 +740,93 @@ describe('Markdown parser', function () {
     });
   });
 
+  it('displays error for annotations in a fence', function () {
+    const example = convert(`
+    ~~~
+    test
+    {% #foo %}
+    test
+    ~~~
+    `);
+
+    expect(Object.values(example.annotations).length).toEqual(0);
+    expect(example.children[0].errors[0]?.id).toEqual('no-inline-annotations');
+  });
+
+  it('correctly identifies inlines', function () {
+    const example = convert(`
+    # This is a test
+
+    {% foo %}
+    Another {% bar %}test{% /bar %} test
+    {% /foo %}
+
+    * bar
+    `);
+
+    expect(example).toDeepEqualSubset({
+      type: 'document',
+      inline: false,
+      children: [
+        {
+          type: 'heading',
+          inline: false,
+          children: [
+            {
+              type: 'inline',
+              inline: false,
+              children: [{ type: 'text', inline: true }],
+            },
+          ],
+        },
+        {
+          type: 'tag',
+          tag: 'foo',
+          inline: false,
+          children: [
+            {
+              type: 'paragraph',
+              inline: false,
+              children: [
+                {
+                  type: 'inline',
+                  inline: false,
+                  children: [
+                    { type: 'text', inline: true },
+                    {
+                      type: 'tag',
+                      tag: 'bar',
+                      inline: true,
+                      children: [{ type: 'text', inline: true }],
+                    },
+                    { type: 'text', inline: true },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'list',
+          inline: false,
+          children: [
+            {
+              type: 'item',
+              inline: false,
+              children: [
+                {
+                  type: 'inline',
+                  inline: false,
+                  children: [{ type: 'text', inline: true }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   describe('handles structural errors correctly', function () {
     it('with unmatched closing tag', function () {
       const example = convert(`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -173,7 +173,7 @@ function handleToken(
 
   if (!Array.isArray(token.children)) return;
 
-  inlineParent = parent;
+  if (node.type === 'inline') inlineParent = parent;
 
   nodes.push(node);
 


### PR DESCRIPTION
This PR fixes issue #390 — annotations inside of fenced code blocks apply their attributes to the top-level document node. The expected behavior is for annotations inside of fenced code blocks to result in a validation error.

The logic inside of the parser sets the value of the `inlineParent` variable to the immediate parent when it detects that the current token has children. This behavior is mostly correct, because in `markdown-it` the only tokens that ever have a `children` array are "inline" tokens. The processing for fenced code blocks is, however, a special case — we modify the token and put the synthesized tokens for the parsed interior text content into the fence's `children` array. This inadvertently results in the fence's parent being treated as the `inlineParent` for the nodes nested inside of the fence.

To address this issue, I modified the parser logic so that it only sets the `inlineParent` variable when the current node type is explicitly "inline". 

Closes #390 