### PR TITLE
Markdoc formatter - update to skip printing undefined attributes

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -782,4 +782,21 @@ ${'`'.repeat(4)}
     check(source, expected);
     stable(expected);
   });
+  it('skips over undefined variables', () => {
+    const sourceNode = new Markdoc.Ast.Node(
+      'tag',
+      {
+        undefinedAttribute: undefined,
+        validAttribute: true
+      },
+      [],
+      'tag'
+    )
+
+    const expected = `{% tag validAttribute=true /%}`
+
+    const b = format(sourceNode);
+    const d = diff(expected, b.trim());
+    if (d && d.includes('Compared values have no visual difference.')) return;
+  })
 });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -787,16 +787,16 @@ ${'`'.repeat(4)}
       'tag',
       {
         undefinedAttribute: undefined,
-        validAttribute: true
+        validAttribute: true,
       },
       [],
       'tag'
-    )
+    );
 
-    const expected = `{% tag validAttribute=true /%}`
+    const expected = `{% tag validAttribute=true /%}`;
 
     const b = format(sourceNode);
     const d = diff(expected, b.trim());
     if (d && d.includes('Compared values have no visual difference.')) return;
-  })
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -81,7 +81,6 @@ function formatAnnotationValue(a: AttributeValue): string | undefined {
   // The Markdoc parser does not support undefined attribute
   // values. Filter those values out.
   return undefined;
-
 }
 
 function* formatAttributes(n: Node) {
@@ -270,7 +269,9 @@ function* formatNode(n: Node, o: Options = {}) {
         yield indent;
       }
       const open = OPEN + SPACE;
-      const attributes = [...formatAttributes(n)].filter((v) => v !== undefined);
+      const attributes = [...formatAttributes(n)].filter(
+        (v) => v !== undefined
+      );
       const tag = [open + n.tag, ...attributes];
       const inlineTag = tag.join(SPACE);
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -70,17 +70,13 @@ function formatScalar(v: Value): string | undefined {
 function formatAnnotationValue(a: AttributeValue): string | undefined {
   const formattedValue = formatScalar(a.value);
 
+  if (formattedValue === undefined) return undefined;
   if (a.name === 'primary') return formattedValue;
   if (a.name === 'id' && typeof a.value === 'string' && isIdentifier(a.value))
     return '#' + a.value;
   if (a.type === 'class' && isIdentifier(a.name)) return '.' + a.name;
 
-  if (formattedValue !== undefined) {
-    return `${a.name}=${formattedValue}`;
-  }
-  // The Markdoc parser does not support undefined attribute
-  // values. Filter those values out.
-  return undefined;
+  return `${a.name}=${formattedValue}`;
 }
 
 function* formatAttributes(n: Node) {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -68,13 +68,12 @@ function formatScalar(v: Value): string | undefined {
 }
 
 function formatAnnotationValue(a: AttributeValue): string | undefined {
-  const formattedValue = formatScalar(a.value)
+  const formattedValue = formatScalar(a.value);
 
   if (a.name === 'primary') return formattedValue;
   if (a.name === 'id' && typeof a.value === 'string' && isIdentifier(a.value))
     return '#' + a.value;
   if (a.type === 'class' && isIdentifier(a.name)) return '.' + a.name;
-
 
   if (formattedValue !== undefined) {
     return `${a.name}=${formattedValue}`;
@@ -272,7 +271,7 @@ function* formatNode(n: Node, o: Options = {}) {
       }
       const open = OPEN + SPACE;
       const attributes = [...formatAttributes(n)];
-      const tag = [open + n.tag, ...attributes.filter(v => v !== undefined)];
+      const tag = [open + n.tag, ...attributes.filter((v) => v !== undefined)];
       const inlineTag = tag.join(SPACE);
 
       const isLongTagOpening =

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -40,14 +40,14 @@ function* formatTableRow(items: Array<string>) {
 }
 
 function formatScalar(v: Value): string | undefined {
+  if (v === undefined) {
+    return undefined;
+  }
   if (Ast.isAst(v)) {
     return format(v);
   }
   if (v === null) {
     return 'null';
-  }
-  if (v === undefined) {
-    return undefined;
   }
   if (Array.isArray(v)) {
     return '[' + v.map(formatScalar).join(SEP) + ']';
@@ -77,11 +77,11 @@ function formatAnnotationValue(a: AttributeValue): string | undefined {
 
   if (formattedValue !== undefined) {
     return `${a.name}=${formattedValue}`;
-  } else {
-    // The Markdoc parser does not support undefined attribute
-    // values. Filter those values out.
-    return undefined;
   }
+  // The Markdoc parser does not support undefined attribute
+  // values. Filter those values out.
+  return undefined;
+
 }
 
 function* formatAttributes(n: Node) {
@@ -270,8 +270,8 @@ function* formatNode(n: Node, o: Options = {}) {
         yield indent;
       }
       const open = OPEN + SPACE;
-      const attributes = [...formatAttributes(n)];
-      const tag = [open + n.tag, ...attributes.filter((v) => v !== undefined)];
+      const attributes = [...formatAttributes(n)].filter((v) => v !== undefined);
+      const tag = [open + n.tag, ...attributes];
       const inlineTag = tag.join(SPACE);
 
       const isLongTagOpening =


### PR DESCRIPTION
See test - the Markdoc parser does not support `undefined` passed into as an attribute. When generating Markdoc this can cause issues because the data source might have undefined values.

Let me know thoughts around this, I am fine with not merging it.

r? @mfix-stripe 