### PR TITLE
Exposes parent nodes in validation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,8 @@ import { truthy } from './src/tags/conditional';
 import Tokenizer from './src/tokenizer';
 import transformer, { globalAttributes } from './src/transformer';
 import transforms from './src/transforms';
-import { parseTags, isPromise } from './src/utils';
-import validator from './src/validator';
+import { parseTags } from './src/utils';
+import validator, { validateTree } from './src/validator';
 
 import type { Node, ParserArgs } from './src/types';
 import type Token from 'markdown-it/lib/token';
@@ -94,25 +94,7 @@ export function validate<C extends Config = Config>(
   options?: C
 ): any {
   const config = mergeConfig(options);
-
-  const output = [content, ...content.walk()].map((node) => {
-    const { type, lines, location } = node;
-    const errors = validator(node, config);
-
-    if (isPromise(errors)) {
-      return errors.then((e) =>
-        e.map((error) => ({ type, lines, location, error }))
-      );
-    }
-
-    return errors.map((error) => ({ type, lines, location, error }));
-  });
-
-  if (output.some(isPromise)) {
-    return Promise.all(output).then((o) => o.flat());
-  }
-
-  return output.flat();
+  return validateTree(content, config);
 }
 
 export function createElement(

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export type ConfigType = Partial<{
   functions: Record<string, ConfigFunction>;
   partials: Record<string, any>;
   validation?: {
+    parents?: Node[];
     validateFunctions?: boolean;
   };
 }>;
@@ -116,7 +117,7 @@ export type SchemaAttribute = {
   default?: any;
   required?: boolean;
   matches?: SchemaMatches | ((config: Config) => SchemaMatches);
-  validate?(value: any, config: Config): ValidationError[];
+  validate?(value: any, config: Config, name: string): ValidationError[];
   errorLevel?: ValidationError['level'];
   description?: string;
 };


### PR DESCRIPTION
This PR modifies the validation logic to maintain an array of a node's parents and pass it into custom validation functions via a config property: `config.validation.parents`. As the `config.validation` property is reserved for Markdoc, adding a new sub-property there should be non-breaking for users (I decided against making it a top-level `config` property in order to avoid conflicts).

There are frequently cases where it is helpful during validation to be able to perform some arbitrary programmatic check on parent nodes further up in the document hierarchy. For example, it may be useful if you want to create a validation function on a custom tag that prevents the user from deeply nesting it inside of another specific tag.

Markdoc AST nodes do not have a property that links to their parent because we want to discourage users from implementing behaviors in transforms that rely on a node's parentage. This makes it easier to operate on subsets of the tree and avoids a bunch of problems that can arise from copying and moving nodes around during transform steps. For the purposes of validation, however, there's no real downside to supporting this feature.

In addition to adding the parent array to `config`, this PR also tweaks the signature of custom attribute functions to add a `name` parameter. This is useful in cases where a single validation function is reused across many attributes and wants to be able to provide clear error reporting on which one triggered the error. As this signature change adds a new parameter, is a non-breaking change that won't affect existing attribute validator functions.