### PR TITLE
Fix conflict between parent validation and function validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -1806,6 +1806,29 @@
           - tag: p
             children: [test]
 
+- name: Hnadling slot that doesn't render
+  config:
+    tags:
+      foo:
+        render: foo
+        slots:
+          bar:
+            render: false
+  slots: true
+  code: |
+    {% foo %}
+    this is a test
+
+    {% slot "bar" %}
+    test
+    {% /slot %}
+    {% /foo %}
+  expected:
+    - tag: foo
+      children:
+        - tag: p
+          children: [this is a test]
+
 - name: Multiline block tags
   config:
     tags:

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -49,6 +49,7 @@ export default {
 
     if (schema.slots) {
       for (const [key, slot] of Object.entries(schema.slots)) {
+        if (slot.render === false) continue;
         const name = typeof slot.render === 'string' ? slot.render : key;
         if (node.slots[key]) output[name] = this.node(node.slots[key], config);
       }

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -1,5 +1,5 @@
 import Markdoc, { nodes } from '../index';
-import type { ValidationError } from './types';
+import type { Config, ValidationError } from './types';
 
 function validate(string, config) {
   return Markdoc.validate(Markdoc.parse(string), config);
@@ -679,6 +679,33 @@ bar
 
       const errors2 = validate(doc2, config);
       expect(errors2.length).toEqual(0);
+    });
+
+    it('with function validation enabled', () => {
+      const doc = `{% foo %}{% bar %}this is a test{% /bar %}{% /foo %}`;
+
+      const config: Config = {
+        validation: {
+          validateFunctions: true,
+        },
+        tags: {
+          foo: {},
+          bar: {
+            validate(node, config) {
+              const parents = config?.validation?.parents?.map((p) => p.type);
+              expect(parents).toDeepEqual([
+                'document',
+                'paragraph',
+                'inline',
+                'tag',
+              ]);
+              return [];
+            },
+          },
+        },
+      };
+
+      validate(doc, config);
     });
   });
 });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -307,8 +307,8 @@ export function validateTree(content: Node, config: Config) {
   const output = [...walkWithParents(content)].map(([node, parents]) => {
     const { type, lines, location } = node;
     const updatedConfig = {
-      validation: { ...config.validation, parents },
       ...config,
+      validation: { ...config.validation, parents },
     };
     const errors = validator(node, updatedConfig);
 


### PR DESCRIPTION
Due to splatting `...config` after populating the `validation` property in `validator.ts`, the parents array would be overwritten whenever the user had a `validation` property in their top-level `config` — notably, when function validation is enabled. This PR fixes that issue and makes parent validation work as expected when function validation is turned on. It also adds a test case to explicitly check that this works.

The PR also adds support for setting `render: false` on a slot. Previously, the `render` attribute for a slot could only be used to change the prop name where the slot appears in the render tree. But there are cases where it's desirable to not have the slot render and be able to manually determine how to handle it in a transform function. I made a one-line change to make `render: false` work, consistent with how the `render` property works on regular tag attributes. I also added a marktest case for it.

Also increments the version number in `package.json` so that I can push a new release after these fixes land.