### PR TITLE
Adds support for dropping location information in `parse` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -52,19 +52,25 @@ describe('Markdown parser', function () {
       });
     });
 
-    it('location off', function() {
-      const example = convert(`# This is a test`, { file: 'foo.md', location: false });
+    it('location off', function () {
+      const example = convert(`# This is a test`, {
+        file: 'foo.md',
+        location: false,
+      });
       expect(example.children[0].location).toBeUndefined();
     });
 
-    it('location on', function() {
-      const example = convert(`# This is a test`, { file: 'foo.md', location: true });
-      const expected = {file: 'foo.md', start: {line: 0}, end: {line: 1}};
+    it('location on', function () {
+      const example = convert(`# This is a test`, {
+        file: 'foo.md',
+        location: true,
+      });
+      const expected = { file: 'foo.md', start: { line: 0 }, end: { line: 1 } };
       expect(example.children[0].location).toDeepEqualSubset(expected);
-      
-      const example2 = convert(`# This is a test`, { file: 'foo.md' }); 
+
+      const example2 = convert(`# This is a test`, { file: 'foo.md' });
       expect(example2.children[0].location).toDeepEqualSubset(expected);
-    })
+    });
   });
 
   describe('handling frontmatter', function () {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -51,6 +51,20 @@ describe('Markdown parser', function () {
         },
       });
     });
+
+    it('location off', function() {
+      const example = convert(`# This is a test`, { file: 'foo.md', location: false });
+      expect(example.children[0].location).toBeUndefined();
+    });
+
+    it('location on', function() {
+      const example = convert(`# This is a test`, { file: 'foo.md', location: true });
+      const expected = {file: 'foo.md', start: {line: 0}, end: {line: 1}};
+      expect(example.children[0].location).toDeepEqualSubset(expected);
+      
+      const example2 = convert(`# This is a test`, { file: 'foo.md' }); 
+      expect(example2.children[0].location).toDeepEqualSubset(expected);
+    })
   });
 
   describe('handling frontmatter', function () {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -101,6 +101,7 @@ function handleToken(
   nodes: Node[],
   file?: string,
   handleSlots?: boolean,
+  addLocation?: boolean,
   inlineParent?: Node
 ) {
   if (token.type === 'frontmatter') {
@@ -150,18 +151,20 @@ function handleToken(
   const { position = {} } = token;
 
   node.errors = errors;
-  node.lines = token.map || parent.lines || [];
-  node.location = {
-    file,
-    start: {
-      line: node.lines[0],
-      character: position.start,
-    },
-    end: {
-      line: node.lines[1],
-      character: position.end,
-    },
-  };
+  if (addLocation !== false) {
+    node.lines = token.map || parent.lines || [];
+    node.location = {
+      file,
+      start: {
+        line: node.lines[0],
+        character: position.start,
+      },
+      end: {
+        line: node.lines[1],
+        character: position.end,
+      },
+    };
+  }
 
   if (inlineParent) node.inline = true;
 
@@ -187,7 +190,7 @@ function handleToken(
   const isLeafNode = typeName === 'image';
   if (!isLeafNode) {
     for (const child of token.children)
-      handleToken(child, nodes, file, handleSlots, inlineParent);
+      handleToken(child, nodes, file, handleSlots, addLocation, inlineParent);
   }
 
   nodes.pop();
@@ -200,7 +203,7 @@ export default function parser(tokens: Token[], args?: string | ParserArgs) {
   if (typeof args === 'string') args = { file: args };
 
   for (const token of tokens)
-    handleToken(token, nodes, args?.file, args?.slots);
+    handleToken(token, nodes, args?.file, args?.slots, args?.location);
 
   if (nodes.length > 1)
     for (const node of nodes.slice(1))

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type ConfigType = Partial<{
   validation?: {
     parents?: Node[];
     validateFunctions?: boolean;
+    environment?: string;
   };
 }>;
 
@@ -168,4 +169,5 @@ export type Value = AstType | Scalar;
 export type ParserArgs = {
   file?: string;
   slots?: boolean;
+  location?: boolean;
 };


### PR DESCRIPTION
This PR introduces a new parse option called `location` — when set to `false`, it causes the parser to not add the `location` property to document `Node` instances and it leaves the `lines` property as an empty array. This is useful in cases where you are caching the parsed AST in memory for use in production and do not need the location information or want the memory overhead that it incurs.

The PR also updates the `Config` type to add a `validation.environment` property. This property can be populated by the end user in order to specify where validation is occurring, so that they can make their custom validation functions perform different behavior in e.g. CI vs the Markdoc language server.