### PR TITLE
Fixes variable resolution for slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -1829,6 +1829,29 @@
         - tag: p
           children: [this is a test]
 
+- name: Slot with a variable
+  config:
+    variables:
+      example: test
+    tags:
+      foo:
+        render: foo
+        slots:
+          bar: {}
+  code: |
+    {% foo %}
+      {% slot "bar" %}
+      This is a {% $example %}
+      {% /slot %}
+    {% /foo %}
+  slots: true
+  expected:
+    - tag: foo
+      attributes:
+        bar:
+          - tag: p
+            children: ['This is a ', 'test']
+
 - name: Multiline block tags
   config:
     tags:

--- a/src/ast/node.ts
+++ b/src/ast/node.ts
@@ -57,6 +57,12 @@ export default class Node implements AstType {
     return Object.assign(new Node(), this, {
       children: this.children.map((child) => child.resolve(config)),
       attributes: resolve(this.attributes, config),
+      slots: Object.fromEntries(
+        Object.entries(this.slots).map(([name, slot]) => [
+          name,
+          slot.resolve(config),
+        ])
+      ),
     });
   }
 


### PR DESCRIPTION
This PR modifies `Node.resolve` to make it resolve slots in addition to children and attributes. This ensures that variables, functions, etc are handled properly inside of the content that is nested in a slot, fixing a bug that caused variables to be passed through to the renderer as plain objects.