### PR TITLE
Fix table cell widths in formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^3.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.3.0",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.3.0",
+      "version": "0.3.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^3.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.5",
+  "version": "0.3.4",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -376,10 +376,10 @@ Yes!
 {% /table %}
     `;
     const expected = `
-| Syntax      | Description |
-| ----------- | ----------- |
-| Header      | Title       |
-| Paragraph   | Text        |
+| Syntax    | Description |
+| --------- | ----------- |
+| Header    | Title       |
+| Paragraph | Text        |
 
 {% table %}
 - One {% align="middle" %}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -382,20 +382,28 @@ function* formatNode(n: Node, o: Options = {}) {
         }
         yield NL;
       } else {
-        yield NL;
+        const widths: number[] = [];
+
+        for (const row of table) {
+          for (let i = 0; i < row.length; i++) {
+            widths[i] = widths[i]
+              ? Math.max(widths[i], row[i].length)
+              : row[i].length;
+          }
+        }
+
         const [head, ...rows] = table as string[][];
 
-        const ml = table
-          .map((arr) => arr.map((s: string) => s.length).reduce(max))
-          .reduce(max);
-
-        yield* formatTableRow(head.map((h) => h + SPACE.repeat(ml - h.length)));
         yield NL;
-        yield* formatTableRow(head.map(() => '-'.repeat(ml)));
+        yield* formatTableRow(
+          head.map((cell, i) => cell + SPACE.repeat(widths[i] - cell.length))
+        );
+        yield NL;
+        yield* formatTableRow(head.map((cell, i) => '-'.repeat(widths[i])));
         yield NL;
         for (const row of rows) {
           yield* formatTableRow(
-            row.map((r) => r + SPACE.repeat(ml - r.length))
+            row.map((cell, i) => cell + SPACE.repeat(widths[i] - cell.length))
           );
           yield NL;
         }


### PR DESCRIPTION
This patch changes the behavior of `Markdoc.format()` for tables. Instead of setting the width of each table cell to the maximum width of all cells in the _table_, this patch will set the width of each table cell to the maximum width of all cells in the _column_. This makes tables significantly more condensed and easier to read.

(It also indirectly fixes a scenario where a `TypeError` was being thrown in cases where `Array.reduce()` was being called for an empty array and with no initial value.)