### PR TITLE
Changes th width property to string type in schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/spec/marktest/tests.yaml
+++ b/spec/marktest/tests.yaml
@@ -712,7 +712,7 @@
 - name: Advanced table format
   code: |
     {% table %}
-    * Test 1 - 1 {% width=20 %}
+    * Test 1 - 1 {% width="20%" %}
     * Test 1 - 2
     * Test 1 - 3
     ---
@@ -733,7 +733,7 @@
               children:
                 - tag: th
                   attributes:
-                    width: 20
+                    width: 20%
                   children: ['Test 1 - 1 ']
                 - tag: th
                   children: [Test 1 - 2]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -145,7 +145,7 @@ export const td: Schema = {
 export const th: Schema = {
   render: 'th',
   attributes: {
-    width: { type: Number },
+    width: { type: String },
     align: { type: String },
     colspan: { type: Number, render: 'colSpan' },
     rowspan: { type: Number, render: 'rowSpan' },


### PR DESCRIPTION
The schema for the `th` node was written to expect a number for the `width` attribute, but when the `width` attribute is rendered literally in markup it needs to be a string. This PR changes the schema and also increments the package's version so we can push an update.

Closes #471