### PR TITLE
Fix escaping image src in formatter

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -162,8 +162,10 @@ regular_word_with_underscores
 {% table %}
 - **[Link](https://example.com?q=()**
 - **[Link](https://example.com?q=\\()**
+- **[Link](https://example.com?q=\\(\\))**
 - ![Image](https://example.com?q=()
 - ![Image](https://example.com?q=\\()
+- ![Image](https://example.com?q=\\(\\))
 {% /table %}
 
 paragraph 1

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -180,7 +180,7 @@ function* formatNode(n: Node, o: Options = {}) {
       yield ']';
       yield '(';
       yield* typeof n.attributes.src === 'string'
-        ? escapeMarkdownCharacters(n.attributes.src, /[()]/)
+        ? escapeMarkdownCharacters(n.attributes.src, /[()]/g)
         : formatValue(n.attributes.src, no);
       if (n.attributes.title) {
         yield SPACE + `"${n.attributes.title}"`;


### PR DESCRIPTION
The regex here was missing the global flag (The one used for links already has the global flag)