### PR TITLE
Fix Typescript error for ^5.4

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { parse, SyntaxError } from './grammar/tag';
+import { parse, type SyntaxError } from './grammar/tag';
 import Variable from './ast/variable';
 import Function from './ast/function';
 


### PR DESCRIPTION
As seen in https://github.com/keystonejs/keystone/pull/9060

```typescript
error TS2866: Import 'SyntaxError' conflicts with global value used in this file, so must be declared with a type-only import when 'isolatedModules' is enabled.

1 import { parse, SyntaxError } from './grammar/tag';
```