### PR TITLE
Add support for custom tag resolution in react render

### DIFF
--- a/src/renderers/react/react.test.ts
+++ b/src/renderers/react/react.test.ts
@@ -67,7 +67,10 @@ describe('React dynamic renderer', function () {
     }
     const components = { Foo: 'bar' };
     const example = new Tag('Foo', undefined, ['test']);
-    const output = dynamic(example, React, {components, resolveTagName: tagName});
+    const output = dynamic(example, React, {
+      components,
+      resolveTagName: tagName,
+    });
 
     expect(output).toDeepEqualSubset({
       name: 'bar',
@@ -187,7 +190,7 @@ describe('React static renderer', function () {
     }
     const components = { Foo: 'bar' };
     const example = new Tag('Foo', undefined, ['test']);
-    const code = renderStatic(example, {resolveTagName: tagName});
+    const code = renderStatic(example, { resolveTagName: tagName });
     const output = eval(code)({ components });
 
     expect(output).toDeepEqualSubset({

--- a/src/renderers/react/react.test.ts
+++ b/src/renderers/react/react.test.ts
@@ -61,6 +61,20 @@ describe('React dynamic renderer', function () {
     });
   });
 
+  it('rendering with a custom tag resolution function', function () {
+    function tagName(name, components) {
+      return components.Foo;
+    }
+    const components = { Foo: 'bar' };
+    const example = new Tag('Foo', undefined, ['test']);
+    const output = dynamic(example, React, {components, resolveTagName: tagName});
+
+    expect(output).toDeepEqualSubset({
+      name: 'bar',
+      children: ['test'],
+    });
+  });
+
   describe('attributes', function () {
     it('with an id attribute', function () {
       const example = {
@@ -159,6 +173,21 @@ describe('React static renderer', function () {
     const components = { Foo: 'bar' };
     const example = new Tag('Foo', undefined, ['test']);
     const code = renderStatic(example);
+    const output = eval(code)({ components });
+
+    expect(output).toDeepEqualSubset({
+      name: 'bar',
+      children: ['test'],
+    });
+  });
+
+  it('rendering with a custom tag resolution function', function () {
+    function tagName(name, components) {
+      return components.Foo;
+    }
+    const components = { Foo: 'bar' };
+    const example = new Tag('Foo', undefined, ['test']);
+    const code = renderStatic(example, {resolveTagName: tagName});
     const output = eval(code)({ components });
 
     expect(output).toDeepEqualSubset({

--- a/src/renderers/react/react.ts
+++ b/src/renderers/react/react.ts
@@ -24,9 +24,9 @@ function tagName(
 }
 
 export type RenderOpts = {
-  components?: Record<string, Component> | ((string: string) => Component)
-  resolveTagName?: typeof tagName
-}
+  components?: Record<string, Component> | ((string: string) => Component);
+  resolveTagName?: typeof tagName;
+};
 export default function dynamic(
   node: RenderableTreeNodes,
   React: ReactShape,

--- a/src/renderers/react/react.ts
+++ b/src/renderers/react/react.ts
@@ -23,10 +23,14 @@ function tagName(
     : components[name];
 }
 
+export type RenderOpts = {
+  components?: Record<string, Component> | ((string: string) => Component)
+  resolveTagName?: typeof tagName
+}
 export default function dynamic(
   node: RenderableTreeNodes,
   React: ReactShape,
-  { components = {} } = {}
+  { components = {}, resolveTagName = tagName }: RenderOpts = {}
 ) {
   function deepRender(value: any): any {
     if (value == null || typeof value !== 'object') return value;
@@ -58,7 +62,7 @@ export default function dynamic(
     if (className) attrs.className = className;
 
     return React.createElement(
-      tagName(name, components),
+      resolveTagName(name, components),
       Object.keys(attrs).length == 0 ? null : deepRender(attrs),
       ...children.map(render)
     );

--- a/src/renderers/react/static.ts
+++ b/src/renderers/react/static.ts
@@ -60,10 +60,18 @@ function render(node: RenderableTreeNodes): string {
     ${renderArray(children)})`;
 }
 
-export default function reactStatic(node: RenderableTreeNodes): string {
+export default function reactStatic(
+  node: RenderableTreeNodes,
+  { resolveTagName = tagName }: { resolveTagName?: typeof tagName } = {}
+): string {
+  // the resolveTagName function *must* be called tagName
+  // throw an error if it does not
+  if (resolveTagName.name !== 'tagName') {
+    throw new Error('resolveTagName must be named tagName');
+  }
   return `
   (({components = {}} = {}) => {
-    ${tagName}
+    ${resolveTagName}
     return ${render(node)};
   })
 `;


### PR DESCRIPTION
Currently, the way in which the react render resolves tag names is hardcoded to a conventional, but not required within react default, of react components always being named with an uppercase letter.

This change allows for users to change how the resolution of tag names to react components occurs. It does so be creating new options to both the dynamic and static react renderers that allows the user to pass a function that overrides the default `tagName` function.

As an example, without this change, if I want to style certain "default" nodes, like the table components (thead, tr, etc), then I must override all of the nodes and then set a name with uppercase letter (like `THead`) and then pass a matching component. This requires a lot more ceremony to use markdoc if the user wants to rely on components instead of stylesheets to change default components.

The motivation for this change comes from how MDX allows the user to also [pass components](https://mdxjs.com/docs/using-mdx/#components) but allows for any arbitrary component, so in some MDX implementations, it becomes a common practice to just define a map of *all* components. See [the following
example.](https://github.com/shadcn-ui/ui/blob/main/apps/www/components/mdx-components.tsx#L41)

 As an alternative, the existing logic *could*
change to *first* check the component repo for a matching name instead of requiring it to be an uppercase letter, but changing that now could be a subtly breaking behavior. This commit instead opts for introducing a new option to the renderers, making this change opt-in.