### PR TITLE
Fix inconsistency between type libraries for markdown-it and linkify-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^3.10.2",
@@ -32,6 +32,7 @@
         "node": ">=14.7.0"
       },
       "optionalDependencies": {
+        "@types/linkify-it": "^3.0.1",
         "@types/markdown-it": "12.2.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "node": ">=14.7.0"
   },
   "optionalDependencies": {
-    "@types/markdown-it": "12.2.3"
+    "@types/markdown-it": "12.2.3",
+    "@types/linkify-it": "^3.0.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Hey there! 😄 

I was updating [apocrypha](https://github.com/nkohari/apocrypha) to the latest version of Markdoc and started running into some type errors:

```
> @apocrypha/core@0.3.0 build:types
> tsc --emitDeclarationOnly --outDir dist

../../node_modules/@types/markdown-it/lib/index.d.ts:151:33 - error TS2694: Namespace '"/Users/nkohari/Work/apocrypha/node_modules/@types/linkify-it/index"' has no exported member 'LinkifyIt'.

151     readonly linkify: LinkifyIt.LinkifyIt;
                                    ~~~~~~~~~

Found 1 error in ../../node_modules/@types/markdown-it/lib/index.d.ts:151
```

Turns out, this is because `@types/markdown-it` depends on any version (`*`) of `@types/linkify-it`, but the latter wasn't reverse-compatible. This patch pins the version of `@types/linkify-it` to the one which is compatible with the the version of the actual `markdown-it` library that Markdoc uses.

Let me know if you have any questions or need more info!