### PR TITLE
Add orderedListMode option to Markdoc.format

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -506,6 +506,48 @@ Yes!
     stable(expected);
   });
 
+  it('human-readable ordered lists', () => {
+    const source = `
+- foo
+- bar
+* baz
+* qux
+
+
+7) foo
+1) bar
+1) baz
+3. foo
+1. bar
+1. baz
+1) foo
+4) bar
+9) baz
+`;
+    const expected = `
+- foo
+- bar
+
+* baz
+* qux
+
+7) foo
+8) bar
+9) baz
+
+3. foo
+4. bar
+5. baz
+
+1) foo
+2) bar
+3) baz
+`;
+    const options = {increasingOlMarkers: true};
+    check(source, expected, options);
+    stable(expected, options);
+  });
+
   it('"loose" lists', () => {
     const source = `
 - a

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -543,7 +543,7 @@ Yes!
 2) bar
 3) baz
 `;
-    const options = {increasingOlMarkers: true};
+    const options = { increasingOlMarkers: true };
     check(source, expected, options);
     stable(expected, options);
   });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -543,7 +543,7 @@ Yes!
 2) bar
 3) baz
 `;
-    const options = { incrementListNumbers: true };
+    const options = { orderedListMode: 'increment' };
     check(source, expected, options);
     stable(expected, options);
   });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -543,7 +543,7 @@ Yes!
 2) bar
 3) baz
 `;
-    const options = { increasingOlMarkers: true };
+    const options = { incrementListNumbers: true };
     check(source, expected, options);
     stable(expected, options);
   });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -506,7 +506,7 @@ Yes!
     stable(expected);
   });
 
-  it('human-readable ordered lists', () => {
+  it('ordered lists with incrementing numbers', () => {
     const source = `
 - foo
 - bar

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,7 +5,7 @@ import type { AttributeValue, Function, Node, Value, Variable } from './types';
 type Options = {
   allowIndentation?: boolean;
   maxTagOpeningWidth?: number;
-  increasingOlMarkers?: boolean;
+  incrementListNumbers?: boolean;
   parent?: Node;
   indent?: number;
 };
@@ -311,7 +311,7 @@ function* formatNode(n: Node, o: Options = {}) {
           const startNumber = n.attributes.start ?? 1;
           if (i === 0) number = startNumber.toString();
 
-          if (o.increasingOlMarkers) {
+          if (o.incrementListNumbers) {
             number = (parseInt(startNumber) + i).toString();
           }
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -315,8 +315,7 @@ function* formatNode(n: Node, o: Options = {}) {
             number = (parseInt(startNumber) + i).toString();
           }
 
-          return `${number}${n.attributes.marker ?? OL}`
-
+          return `${number}${n.attributes.marker ?? OL}`;
         })();
         let d = format(n.children[i], increment(no, prefix.length + 1));
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,7 +5,7 @@ import type { AttributeValue, Function, Node, Value, Variable } from './types';
 type Options = {
   allowIndentation?: boolean;
   maxTagOpeningWidth?: number;
-  incrementListNumbers?: boolean;
+  orderedListMode?: 'increment' | 'repeat';
   parent?: Node;
   indent?: number;
 };
@@ -311,7 +311,7 @@ function* formatNode(n: Node, o: Options = {}) {
           const startNumber = n.attributes.start ?? 1;
           if (i === 0) number = startNumber.toString();
 
-          if (o.incrementListNumbers) {
+          if (o.orderedListMode === 'increment') {
             number = (parseInt(startNumber) + i).toString();
           }
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,6 +5,7 @@ import type { AttributeValue, Function, Node, Value, Variable } from './types';
 type Options = {
   allowIndentation?: boolean;
   maxTagOpeningWidth?: number;
+  increasingOlMarkers?: boolean;
   parent?: Node;
   indent?: number;
 };
@@ -302,11 +303,21 @@ function* formatNode(n: Node, o: Options = {}) {
       );
 
       for (let i = 0; i < n.children.length; i++) {
-        const prefix = n.attributes.ordered
-          ? `${i === 0 ? n.attributes.start ?? '1' : '1'}${
-              n.attributes.marker ?? OL
-            }`
-          : n.attributes.marker ?? UL;
+        const prefix = (() => {
+          if (!n.attributes.ordered) return n.attributes.marker ?? UL;
+
+          // Must be an ordered list now
+          let number = '1';
+          const startNumber = n.attributes.start ?? 1;
+          if (i === 0) number = startNumber.toString();
+
+          if (o.increasingOlMarkers) {
+            number = (parseInt(startNumber) + i).toString();
+          }
+
+          return `${number}${n.attributes.marker ?? OL}`
+
+        })();
         let d = format(n.children[i], increment(no, prefix.length + 1));
 
         if (!isLoose || i === n.children.length - 1) {


### PR DESCRIPTION
Adds an `orderedListMode` option to the `Options` accepted by `Markdoc.format` such that when set to `'increment'`, calling `Markdoc.format` on the AST resulting from parsing

```
1. Foo
2. Bar
3. Baz
```

would not be changed to

```
1. Foo
1. Bar
1. Baz
```

and similarly, the latter as input WOULD get formatted to the former.