### PR TITLE
Fix formatting fences when content has no final newline

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -843,4 +843,9 @@ ${'`'.repeat(4)}
     const d = diff(expected, b.trim());
     if (d && d.includes('Compared values have no visual difference.')) return;
   });
+
+  it('makes sure fences are formatted correctly if content has no ending newline', () => {
+    const node = new Markdoc.Ast.Node('fence', {content: 'foo'})
+    expect(format(node)).toEqual('```\nfoo\n```\n')
+  })
 });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -845,7 +845,7 @@ ${'`'.repeat(4)}
   });
 
   it('makes sure fences are formatted correctly if content has no ending newline', () => {
-    const node = new Markdoc.Ast.Node('fence', {content: 'foo'})
-    expect(format(node)).toEqual('```\nfoo\n```\n')
-  })
+    const node = new Markdoc.Ast.Node('fence', { content: 'foo' });
+    expect(format(node)).toEqual('```\nfoo\n```\n');
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -248,7 +248,7 @@ function* formatNode(n: Node, o: Options = {}) {
         .reduce(max, 0);
 
       const boundary = '`'.repeat(innerFenceLength ? innerFenceLength + 1 : 3);
-      const needsNlBeforeEndBoundary = !n.attributes.content.endsWith(NL)
+      const needsNlBeforeEndBoundary = !n.attributes.content.endsWith(NL);
 
       yield boundary;
       if (n.attributes.language) yield n.attributes.language;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -248,6 +248,7 @@ function* formatNode(n: Node, o: Options = {}) {
         .reduce(max, 0);
 
       const boundary = '`'.repeat(innerFenceLength ? innerFenceLength + 1 : 3);
+      const needsNlBeforeEndBoundary = !n.attributes.content.endsWith(NL)
 
       yield boundary;
       if (n.attributes.language) yield n.attributes.language;
@@ -256,6 +257,9 @@ function* formatNode(n: Node, o: Options = {}) {
       yield NL;
       yield indent;
       yield n.attributes.content.split(NL).join(NL + indent); // yield* formatChildren(n, no);
+      if (needsNlBeforeEndBoundary) {
+        yield NL;
+      }
       yield boundary;
       yield NL;
       break;


### PR DESCRIPTION
Formatting a fence node with content set to "foo" previously produced

    ```
    foo```

which doesn't parse correctly (the backticks are included in the content; if there is more markup following such fence block the markup can also be misinterpreted as the contents).