### PR TITLE
Re-export Node in a way that allows runtime use

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import Ast from './src/ast';
+import Node from './src/ast/node';
 import format from './src/formatter';
 import functions from './src/functions';
 import parser from './src/parser';
@@ -13,7 +14,7 @@ import transforms from './src/transforms';
 import { parseTags } from './src/utils';
 import validator, { validateTree } from './src/validator';
 
-import type { Node, ParserArgs } from './src/types';
+import type { ParserArgs } from './src/types';
 import type Token from 'markdown-it/lib/token';
 import type { Config, RenderableTreeNode, ValidateError } from './src/types';
 
@@ -113,6 +114,7 @@ export {
   transforms,
   renderers,
   Ast,
+  Node,
   Tag,
   Tokenizer,
   parseTags,


### PR DESCRIPTION
Previously it wasn't possible to have code like

    import { Node } from '@markdoc/markdoc'

    function f(): Node {
        // error below: 'Node' cannot be used as a value because it was exported using 'export type'.ts(1362)
        return new Node('tag', {}, [], 'foo')
    }

This patch rectifies that and we can have the same type used in return type position and the class instantiation position.

Resolves: https://github.com/markdoc/markdoc/issues/539