### PR TITLE
Fix #544 - Component type mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/renderers/react/react.ts
+++ b/src/renderers/react/react.ts
@@ -8,7 +8,7 @@ type ReactShape = Readonly<{
   Fragment: typeof Fragment;
 }>;
 
-type Component = ComponentType<unknown>;
+type Component = ComponentType<any>;
 
 function tagName(
   name: string,


### PR DESCRIPTION
Fixes #544 

https://github.com/markdoc/markdoc/pull/496 added more type safety to the `Markdoc.renderers.react` function, but `type Component = ComponentType<unknown>;` is too strict and breaks existing examples. There is not type information about the props that are used for all of these components which is why `unknown` will throw an error.


### Test plan
I created a `dist.tsx` file with a repro of this issue and this change fixed the error.

r? @mfix-stripe 