### PR TITLE
Validation Context

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -88,14 +88,16 @@ export function transform<C extends Config = Config>(
 
 export function validate<C extends Config = Config>(
   node: Node,
-  options?: C
+  options?: C,
+  context?: unknown
 ): ValidateError[];
 export function validate<C extends Config = Config>(
   content: any,
-  options?: C
+  options?: C,
+  context?: unknown
 ): any {
   const config = mergeConfig(options);
-  return validateTree(content, config);
+  return validateTree(content, config, context);
 }
 
 export function createElement(

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,12 +39,17 @@ export type ConfigFunction = {
   returns?: ValidationType | ValidationType[];
   parameters?: Record<string, SchemaAttribute>;
   transform?(parameters: Record<string, any>, config: Config): any;
-  validate?(fn: Func, config: Config): ValidationError[];
+  validate?(fn: Func, config: Config, context?: unknown): ValidationError[];
 };
 
 export interface CustomAttributeTypeInterface {
   transform?(value: any, config: Config): Scalar;
-  validate?(value: any, config: Config, name: string): ValidationError[];
+  validate?(
+    value: any,
+    config: Config,
+    name: string,
+    context?: unknown
+  ): ValidationError[];
 }
 
 export interface CustomAttributeType {
@@ -108,7 +113,11 @@ export type Schema<C extends Config = Config, R = string> = {
   selfClosing?: boolean;
   inline?: boolean;
   transform?(node: Node, config: C): MaybePromise<RenderableTreeNodes>;
-  validate?(node: Node, config: C): MaybePromise<ValidationError[]>;
+  validate?(
+    node: Node,
+    config: C,
+    context?: unknown
+  ): MaybePromise<ValidationError[]>;
   description?: string;
 };
 
@@ -118,7 +127,12 @@ export type SchemaAttribute = {
   default?: any;
   required?: boolean;
   matches?: SchemaMatches | ((config: Config) => SchemaMatches);
-  validate?(value: any, config: Config, name: string): ValidationError[];
+  validate?(
+    value: any,
+    config: Config,
+    name: string,
+    context?: unknown
+  ): ValidationError[];
   errorLevel?: ValidationError['level'];
   description?: string;
 };


### PR DESCRIPTION
Allows passing a context to `Markdoc.validate` that then gets passed to all `validate` functions in the schema.

I'm building a fairly complex markdown editing experience with many components on top of Markdoc and needed the ability to have information about the rest of the editing environment within the `validate` functions. Without this `context`, I would have to use some global state and import it everywhere. Allowing `context` to be passed through keeps the schemas much more isolated and independent.

Using the `context` is completely optional (the argument is optional everywhere), so this is backwards compatible and shouldn't cause any issues