### PR TITLE
Fix infinite loop when tokenizing HTML comments spread across multiple lines

### DIFF
--- a/src/tokenizer/plugins/comments.test.ts
+++ b/src/tokenizer/plugins/comments.test.ts
@@ -90,5 +90,31 @@ describe('MarkdownIt Comments plugin', function () {
 
       expect(example).toDeepEqualSubset(output);
     });
+
+    it('block comment across multiple lines with blank lines', function () {
+      const actual = tokenizer.tokenize(
+        `
+      foo <!-- example
+
+      comment --> bar
+      `.trim()
+      );
+
+      const expected = [
+        { type: 'paragraph_open' },
+        {
+          type: 'inline',
+          children: [
+            { type: 'text', content: 'foo <!-- example' },
+          ],
+        },
+        { type: 'paragraph_close' },
+        { type: 'paragraph_open' },
+        { type: 'inline', content: 'comment --> bar' },
+        { type: 'paragraph_close' },
+      ];
+
+      expect(actual).toDeepEqualSubset(expected);
+    });
   });
 });

--- a/src/tokenizer/plugins/comments.test.ts
+++ b/src/tokenizer/plugins/comments.test.ts
@@ -104,9 +104,7 @@ describe('MarkdownIt Comments plugin', function () {
         { type: 'paragraph_open' },
         {
           type: 'inline',
-          children: [
-            { type: 'text', content: 'foo <!-- example' },
-          ],
+          children: [{ type: 'text', content: 'foo <!-- example' }],
         },
         { type: 'paragraph_close' },
         { type: 'paragraph_open' },

--- a/src/tokenizer/plugins/comments.ts
+++ b/src/tokenizer/plugins/comments.ts
@@ -16,7 +16,7 @@ function block(
 
   const close = state.src.indexOf(CLOSE, start);
 
-  if (!close) return false;
+  if (close === -1) return false;
   if (silent) return true;
 
   const content = state.src.slice(start + OPEN.length, close);
@@ -34,7 +34,7 @@ function inline(state: StateInline, silent: boolean): boolean {
 
   const close = state.src.indexOf(CLOSE, state.pos);
 
-  if (!close) return false;
+  if (close === -1) return false;
   if (silent) return true;
 
   const content = state.src.slice(state.pos + OPEN.length, close);


### PR DESCRIPTION
Take the example in the test provided:
```md
foo <!-- example

comment --> bar
```

Without the change in this PR, the `tokenize` call hangs because it goes through an infinite loop. The blank line between the two lines in the test means they're parsed as separate paragraphs, so the block rule never applies. The bug is in the `inline` rule, here:
```ts
  const start = state.bMarks[startLine] + state.tShift[startLine];
  if (!state.src.startsWith(OPEN, start)) return false;

  const close = state.src.indexOf(CLOSE, state.pos);

  if (!close) return false;
  if (silent) return true;

  const content = state.src.slice(state.pos + OPEN.length, close);
  const token = state.push('comment', '', 0);
  token.content = content.trim();
  state.pos = close + CLOSE.length;
```

Tokenization goes fine for the `foo`, and then we evaluate this rule midway through the first line. `start`, the index of the `<!--` sigil, will be 4, and the `startsWith` call will correctly return `true`. Moving on, `close` will be -1; since the comment is split over multiple lines, the --> is not in the same line and can't be found. After constructing `content` and pushing a `token`, `state.pos` will be set to `-1 + "-->".length()` == `2`. This is _less_ than `start`, so we'll actually move the pointer `state.pos` backwards, and tokenization will run back into this case on its next go-round and hit the same case again.

This leads to an infinite loop, which hangs our app when an HTML comment gets split over multiple lines like that.

I think it'd be maximally correct for the example to produce
```
foo

bar
```

Unfortunately, however, HTML comment syntax is neither really inline nor block; it can be used as an inline or block tag, and Markdoc supports that, but this maximal correctness case seems hard to replicate with my (beginner!) knowledge of Markdoc. More than open to suggestions on ways this can be fixed in that way, but I figure that it is _more_ correct to produce the verbatim input rather than to infinitely hang the tokenizer :)

Includes a test.