### PR TITLE
Update `format()` to accept both single and array value params

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -453,7 +453,7 @@ function* formatNode(n: Node, o: Options = {}) {
 }
 
 function* formatValue(
-  v: Value,
+  v: Value | Value[],
   o: Options = {}
 ): Generator<string, void, unknown> {
   switch (typeof v) {
@@ -491,7 +491,7 @@ function* formatValue(
   }
 }
 
-export default function format(v: Value, options?: Options): string {
+export default function format(v: Value | Value[], options?: Options): string {
   let doc = '';
   for (const s of formatValue(v, options)) doc += s;
   return doc.trimStart();


### PR DESCRIPTION
`format` and `formatValue` support array type inputs:

https://github.com/markdoc/markdoc/blob/a1b6a37b6b033952705be34acefa097dc7b32a35/src/formatter.ts#L468-L473

but their type signature `Value` doesn't include array type. This results in callers having to use a type assertion when calling `Markdoc.format` with an array of nodes.

This PR updates the function type signature to accept array types. There are no behavioral changes.
