### PR TITLE
Added Conditional attribute type to allow boolean values

### DIFF
--- a/src/schema-types/conditional.ts
+++ b/src/schema-types/conditional.ts
@@ -1,0 +1,34 @@
+import {
+  Config,
+  CustomAttributeTypeInterface,
+  ValidationError,
+} from '../types';
+
+/**
+ * Conditional attribute type for Markdoc {% if /%} and {% else /%} tags.
+ * 
+ * Acceptable values are:
+ * - `boolean` (true or false)
+ * - `null` or `undefined` (in case of using variable that's not defined)
+ * - `object`
+ */
+export class ConditionalAttributeType implements CustomAttributeTypeInterface {
+  validate(value: any, _config: Config, key: string): ValidationError[] {
+    if (
+      typeof value === 'boolean' ||
+      value === null ||
+      value === undefined ||
+      typeof value === 'object'
+  ) {
+      return [];
+  }
+
+    return [
+      {
+        id: 'attribute-type-invalid',
+        level: 'error',
+        message: `Attribute '${key}' must be type 'boolean | object' (null or undefined are also allowed)`,
+      },
+    ];
+  }
+}

--- a/src/schema-types/conditional.ts
+++ b/src/schema-types/conditional.ts
@@ -6,7 +6,7 @@ import {
 
 /**
  * Conditional attribute type for Markdoc {% if /%} and {% else /%} tags.
- * 
+ *
  * Acceptable values are:
  * - `boolean` (true or false)
  * - `null` or `undefined` (in case of using variable that's not defined)
@@ -19,9 +19,9 @@ export class ConditionalAttributeType implements CustomAttributeTypeInterface {
       value === null ||
       value === undefined ||
       typeof value === 'object'
-  ) {
+    ) {
       return [];
-  }
+    }
 
     return [
       {

--- a/src/tags/conditional.ts
+++ b/src/tags/conditional.ts
@@ -8,6 +8,7 @@ import {
   Schema,
   Value,
 } from '../types';
+import { ConditionalAttributeType } from '../schema-types/conditional';
 
 type Condition = { condition: Value; children: Node[] };
 
@@ -34,7 +35,7 @@ function renderConditions(node: Node) {
 
 export const tagIf: Schema = {
   attributes: {
-    primary: { type: Object, render: false },
+    primary: { type: ConditionalAttributeType, render: false },
   },
 
   transform(node, config) {
@@ -56,6 +57,6 @@ export const tagIf: Schema = {
 export const tagElse: Schema = {
   selfClosing: true,
   attributes: {
-    primary: { type: Object, render: false },
+    primary: { type: ConditionalAttributeType, render: false },
   },
 };


### PR DESCRIPTION
- [x] Added Conditional attribute type to allow boolean values in addition to variables and objects.

Testing on the following example:
```
{% if true %}

{% callout type="note" %}
Tags are composable!
{% /callout %}

{% else /%}

{% callout type="warning" %}
Tags aren't composable!
{% /callout %}

{% /if %}
```

#### Before 
<img width="400" alt="" src="https://github.com/user-attachments/assets/85950f14-97ee-46e5-8f40-814053334535" />

#### After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c25525ca-4f3d-4ce6-9019-d0773dc5ff34" />
