### PR TITLE
Update formatter regex for list items and headings

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -149,11 +149,15 @@ regular_word_with_underscores
 
 \\### Heading
 
+#Not a heading
+
 **/docs/\\***
 
 ~~**a \\_sentence\\_ with \\_underscores**~~
 
 - Item with [brackets]
+
+-not a list item
 
 \`\`\`
 \\*\\_[\\[]

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -216,7 +216,7 @@ function* formatNode(n: Node, o: Options = {}) {
           yield* escapeMarkdownCharacters(content, /[*_~]/g);
         } else {
           // Escape > blockquote, * list item, and heading
-          yield* escapeMarkdownCharacters(content, /^[*>#]/);
+          yield* escapeMarkdownCharacters(content, /^\*|#+\s|>/);
         }
       }
 


### PR DESCRIPTION
Fixes a small bug with the markdoc formatter where certain strings were incorrectly escaped as markdown characters. For example `#not a heading` would get escaped as `\#heading` or `*Not a list item` would get escaped to `\*Not a list item` when they should be maintained. Both `>blockquote` and `> blockquote` are valid blockquotes.

[Commonmark playground to demonstrate examples](https://spec.commonmark.org/dingus/?text=%23%20is%20a%20heading%0A%0A%23%23is%20not%20a%20heading%0A%0A-%20is%20a%20list%20item%0A%0A-is%20not%20a%20list%20item%0A%0A%3Eis%20a%20blockquote%0A%0A%3Eis%20also%20a%20blockquote)