### PR TITLE
Fix incorrectly escaped angled brackets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^3.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -145,6 +145,8 @@ regular_word_with_underscores
 
 \\> Blockquote
 
+Text > not a blockquote
+
 \\# Heading
 
 \\### Heading

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -224,7 +224,7 @@ function* formatNode(n: Node, o: Options = {}) {
           yield* escapeMarkdownCharacters(content, /[*_~]/g);
         } else {
           // Escape > blockquote, * list item, and heading
-          yield* escapeMarkdownCharacters(content, /^\*|#+\s|>/);
+          yield* escapeMarkdownCharacters(content, /^\*|#+\s|^>/);
         }
       }
 


### PR DESCRIPTION
https://github.com/markdoc/markdoc/pull/582 introduced a bug where angled brackets were being incorrectly escaped, e.g. `text>not a blockquote` was getting escaped to `text\>not a blockquote`