### PR TITLE
Fix: nested tags indented with tabs fail to parse (fixes #581)

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -744,6 +744,35 @@ describe('Markdown parser', function () {
     }).not.toThrow();
   });
 
+  it('parsing nested tags indented with tabs should produce correct nesting', function () {
+    // Regression test for https://github.com/markdoc/markdoc/issues/581
+    // A single tab expands to 4 visual columns, which previously caused
+    // markdown-it's paragraph rule to swallow the tab-indented closing tag.
+    const tabTokenizer = new Tokenizer();
+    const content =
+      '{% tag1 %}\n\t{% tag2 %}\n\t\tContents\n\t{% /tag2 %}\n{% /tag1 %}';
+    const tokens = tabTokenizer.tokenize(content);
+    const ast = parser(tokens);
+    expect(ast.errors).toDeepEqual([]);
+    expect(ast).toDeepEqualSubset({
+      type: 'document',
+      children: [
+        {
+          type: 'tag',
+          tag: 'tag1',
+          errors: [],
+          children: [
+            {
+              type: 'tag',
+              tag: 'tag2',
+              errors: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('parsing comments', function () {
     const example = convert(`
     this is a test

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -20,7 +20,10 @@ export default class Tokenizer {
     // single tab), causing tab-indented nested tags like `\t{% /tag %}` to
     // be swallowed into the preceding paragraph instead of being recognised
     // as block-level annotations. See https://github.com/markdoc/markdoc/issues/581
-    this.parser = new MarkdownIt({ allowIndentation: true, ...config } as MarkdownIt.Options);
+    this.parser = new MarkdownIt({
+      allowIndentation: true,
+      ...config,
+    } as MarkdownIt.Options);
     this.parser.use(annotations, 'annotations', {});
     this.parser.use(frontmatter, 'frontmatter', {});
     this.parser.disable([

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -13,7 +13,14 @@ export default class Tokenizer {
       allowComments?: boolean;
     } = {}
   ) {
-    this.parser = new MarkdownIt(config);
+    // Default allowIndentation to true: markdoc already disables the indented
+    // code_block rule, so there is no ambiguity between a tab-indented line
+    // and a code block. Without this default, markdown-it's paragraph rule
+    // skips terminator checks for lines whose visual indent >= 4 (e.g. a
+    // single tab), causing tab-indented nested tags like `\t{% /tag %}` to
+    // be swallowed into the preceding paragraph instead of being recognised
+    // as block-level annotations. See https://github.com/markdoc/markdoc/issues/581
+    this.parser = new MarkdownIt({ allowIndentation: true, ...config } as MarkdownIt.Options);
     this.parser.use(annotations, 'annotations', {});
     this.parser.use(frontmatter, 'frontmatter', {});
     this.parser.disable([


### PR DESCRIPTION
## Summary

Fixes #581.

In `Tokenizer`, default `allowIndentation` to `true` so that block-level annotations (e.g. `{% /tag %}`) indented with tabs are recognised correctly as block elements, not absorbed into a preceding paragraph.

---

## Root Cause

markdown-it's `paragraph` rule contains the following guard:

```js
// rules_block/paragraph.js
if (!state.md.options.allowIndentation && state.sCount[nextLine] - state.blkIndent > 3) { continue; }
```

When `allowIndentation` is `false` (the default) and a line's visual indent is ≥ 4 columns, the paragraph rule **skips** all terminator-rule checks for that line and treats it as lazy continuation. A single tab expands to 4 visual columns (`sCount = 4`), so a tab-indented line like `\t{% /callout %}` is never tested by the annotations block rule and gets swallowed into the preceding paragraph. The outer opening tag then has no matching closing tag, which produces:

```
Node 'callout' is missing closing   (opening tag)
Node 'tag' is missing opening       (closing tag — treated as new block)
```

---

## Solution

Set `allowIndentation: true` as the default when creating the internal MarkdownIt parser in `src/tokenizer/index.ts`:

```ts
this.parser = new MarkdownIt({ allowIndentation: true, ...config } as MarkdownIt.Options);
```

Markdoc already explicitly disables the `'code'` rule (indented code blocks), so there is no ambiguity between a tab-indented line and a code block. `allowIndentation: true` simply tells markdown-it to check terminator rules for all indented lines, regardless of their visual column count. Users who relied on the old (broken) behaviour can restore it by passing `allowIndentation: false` to the `Tokenizer` constructor, but in practice this was never a useful option with the `'code'` rule disabled.

---

## Testing

- Added `'parsing nested tags indented with tabs should produce correct nesting'` in `src/parser.test.ts` — exercises the exact scenario from issue #581 (`{% tag1 %}` → `\t{% tag2 %}` → `\t\tContents` → `\t{% /tag2 %}` → `{% /tag1 %}`) and asserts zero parse errors and correct AST nesting.
- All existing 260 specs still pass.

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New test covers the exact failing scenario from the issue
- [x] All existing tests pass (`260 specs, 0 failures`)
- [x] No unrelated changes
- [x] Code style matches project conventions