### PR TITLE
Fix: escaped links/images/autolinks lose backslash in Markdoc.format (fixes #590)

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -855,4 +855,29 @@ ${'`'.repeat(4)}
     const node = new Markdoc.Ast.Node('fence', { content: 'foo' });
     expect(format(node)).toEqual('```\nfoo\n```\n');
   });
+
+  it('preserves escaping on links, images, and autolinks (issue #590)', () => {
+    // \[text](url) — escaped [ must be re-emitted so it stays plain text.
+    // stable() requires a trailing \n because format appends one for paragraphs.
+    stable(String.raw`\[a](https://example.com)` + '\n');
+
+    // \<url> — escaped autolink must stay plain text, not become an autolink
+    stable(String.raw`\<https://example.com>` + '\n');
+
+    // [brackets] with no following (url) must not gain a spurious backslash
+    stable('Item with [brackets]\n');
+
+    // <not-an-autolink> must not gain a spurious backslash
+    stable('<not-an-autolink>\n');
+
+    // \!\[text](url) — the parser collapses \! and \[ into the single text
+    // node "![a](url)". The formatter escapes the [ (producing !\[...]) which
+    // is semantically equivalent and round-trips to the same content.
+    const ast = Markdoc.parse(String.raw`\!\[a](https://example.com)`);
+    const reparsed = Markdoc.parse(format(ast));
+    const content =
+      reparsed.children?.[0]?.children?.[0]?.children?.[0]?.attributes
+        ?.content;
+    expect(content).toEqual('![a](https://example.com)');
+  });
 });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -876,8 +876,7 @@ ${'`'.repeat(4)}
     const ast = Markdoc.parse(String.raw`\!\[a](https://example.com)`);
     const reparsed = Markdoc.parse(format(ast));
     const content =
-      reparsed.children?.[0]?.children?.[0]?.children?.[0]?.attributes
-        ?.content;
+      reparsed.children?.[0]?.children?.[0]?.children?.[0]?.attributes?.content;
     expect(content).toEqual('![a](https://example.com)');
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -8,6 +8,7 @@ type Options = {
   orderedListMode?: 'increment' | 'repeat';
   parent?: Node;
   indent?: number;
+  nextSibling?: Node;
 };
 
 const SPACE = ' ';
@@ -27,8 +28,12 @@ const increment = (o: Options, n = 2) => ({
 });
 
 function* formatChildren(a: Node, options: Options) {
-  for (const child of a.children) {
-    yield* formatValue(child, options);
+  const children = a.children;
+  for (let i = 0; i < children.length; i++) {
+    yield* formatValue(children[i], {
+      ...options,
+      nextSibling: children[i + 1],
+    });
   }
 }
 
@@ -140,6 +145,35 @@ function* escapeMarkdownCharacters(s: string, characters: RegExp) {
     .replace(new RegExp('\xa0', 'g'), '&nbsp;');
 }
 
+/**
+ * Returns true if the string starting at `offset` begins a [text](url)
+ * pattern that would be parsed as a link. Uses CommonMark's balanced-
+ * parenthesis rule for link destinations so that patterns with unbalanced
+ * parens — which the parser already treats as plain text — are not touched.
+ */
+function startsWithLink(s: string, offset: number): boolean {
+  let i = offset;
+  if (s[i] !== '[') return false;
+  i++;
+  // scan to closing ]
+  while (i < s.length && s[i] !== ']') i++;
+  if (i >= s.length || s[i + 1] !== '(') return false;
+  i += 2; // skip ](
+  // scan URL counting balanced parens
+  let depth = 1;
+  while (i < s.length) {
+    if (s[i] === '(') depth++;
+    else if (s[i] === ')') {
+      depth--;
+      if (depth === 0) return true;
+    } else if (s[i] === ' ' || s[i] === '\t' || s[i] === '\n') {
+      return false; // unquoted whitespace makes the URL invalid
+    }
+    i++;
+  }
+  return false;
+}
+
 function* formatNode(n: Node, o: Options = {}) {
   const no = { ...o, parent: n };
   const indent = SPACE.repeat(no.indent || 0);
@@ -219,12 +253,30 @@ function* formatNode(n: Node, o: Options = {}) {
         yield* formatValue(content, no);
         yield SPACE + CLOSE;
       } else {
+        // Escape [ that starts a valid inline link [text](url) — only when
+        // the destination has balanced parens (what the parser treats as a link).
+        // Leaves patterns with unbalanced parens alone; they already round-trip
+        // as plain text without escaping.
+        let escaped = content.replace(/\[/g, (_, offset) =>
+          startsWithLink(content, offset) ? '\\[' : '['
+        );
+        // Escape < that would be parsed as an autolink <scheme://...>
+        escaped = escaped.replace(
+          /<(?=[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^>]*>)/g,
+          '\\<'
+        );
+        // Escape trailing ! when the next sibling is a link node so that the
+        // sequence ![ ... ]( ... ) is not re-parsed as an image.
+        if (o.nextSibling?.type === 'link' && escaped.endsWith('!')) {
+          escaped = escaped.slice(0, -1) + '\\!';
+        }
+
         if (o.parent && WRAPPING_TYPES.includes(o.parent.type)) {
           // Escape **strong**, _em_, and ~~s~~
-          yield* escapeMarkdownCharacters(content, /[*_~]/g);
+          yield* escapeMarkdownCharacters(escaped, /[*_~]/g);
         } else {
           // Escape > blockquote, * list item, and heading
-          yield* escapeMarkdownCharacters(content, /^\*|#+\s|^>/);
+          yield* escapeMarkdownCharacters(escaped, /^\*|#+\s|^>/);
         }
       }
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -257,7 +257,7 @@ function* formatNode(n: Node, o: Options = {}) {
         // the destination has balanced parens (what the parser treats as a link).
         // Leaves patterns with unbalanced parens alone; they already round-trip
         // as plain text without escaping.
-        let escaped = content.replace(/\[/g, (_, offset) =>
+        let escaped = content.replace(/\[/g, (_: string, offset: number) =>
           startsWithLink(content, offset) ? '\\[' : '['
         );
         // Escape < that would be parsed as an autolink <scheme://...>


### PR DESCRIPTION
## Summary

Fixes #590.

`Markdoc.format` was emitting text nodes verbatim, so a text node whose content happened to be `[a](url)` (produced by parsing `\[a](url)`) was written back as `[a](url)` — which the parser re-reads as a link. The original escaping was silently dropped on every format round-trip.

---

## Root Cause

In `formatter.ts`, the `'text'` case of `formatNode` (previously line 214) passed `content` directly to `escapeMarkdownCharacters`. That helper only re-escaped characters that could form headings, blockquotes, or emphasis — it had no knowledge of inline-link or autolink syntax.

Three patterns broke:

| Input | Stored text-node content | Old output | Re-parsed as |
|-------|--------------------------|------------|--------------|
| `\[a](url)` | `[a](url)` | `[a](url)` | **link** ✗ |
| `\!\[a](url)` | `![a](url)` | `![a](url)` | **image** ✗ |
| `\<https://example.com>` | `<https://example.com>` | `<https://example.com>` | **autolink** ✗ |

---

## Solution

Three targeted guards are applied to `content` **before** the existing per-character escaping:

1. **`startsWithLink(content, offset)`** — a small scanner that follows CommonMark's balanced-parenthesis rule for link destinations. It escapes `[` only when it genuinely opens an inline link `[text](url)`. Patterns such as `![Image](url_with_unbalanced_parens)` — which the parser already treats as plain text — are left untouched.

2. **`/<scheme:\/\/...>/` regex** — escapes `<` that would be re-parsed as a scheme-based autolink (e.g. `<https://example.com>`).

3. **`nextSibling` tracking** — `formatChildren` now forwards the next sibling into each child's options. When a `text` node ends with `!` and its next sibling is a `link` node (the AST shape produced by `\![link](url)`), the trailing `!` is escaped to `\!`, preventing the sequence from being re-read as an image.

---

## Testing

- Added `'preserves escaping on links, images, and autolinks (issue #590)'` in `src/formatter.test.ts`:
  - `\[a](url)` round-trips stably (formatter re-emits `\[`)
  - `\<https://example.com>` round-trips stably (formatter re-emits `\<`)
  - `[brackets]` (no URL) gains no spurious backslash
  - `<not-an-autolink>` gains no spurious backslash
  - `\!\[a](url)` re-parses to the same text-node content (`![a](url)`)
- All **260 existing specs** still pass.
- Run with: `npm test`

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New tests cover the exact scenarios from issue #590
- [x] All existing tests pass (260 specs, 0 failures)
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Lint clean (`npm run lint` — no errors)