### PR TITLE
Fix: transform() return type to MaybePromise and handle async array case (fixes #495)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,14 @@ import validator, { validateTree } from './src/validator';
 
 import type { ParserArgs } from './src/types';
 import type Token from 'markdown-it/lib/token';
-import type { Config, RenderableTreeNode, ValidateError } from './src/types';
+import type {
+  Config,
+  MaybePromise,
+  RenderableTreeNode,
+  RenderableTreeNodes,
+  ValidateError,
+} from './src/types';
+import { isPromise } from './src/utils';
 
 export * from './src/types';
 
@@ -69,21 +76,33 @@ export function resolve<C extends Config = Config>(
 export function transform<C extends Config = Config>(
   node: Node,
   config?: C
-): RenderableTreeNode;
+): MaybePromise<RenderableTreeNode>;
 export function transform<C extends Config = Config>(
   nodes: Node[],
   config?: C
-): RenderableTreeNode[];
+): MaybePromise<RenderableTreeNode[]>;
 export function transform<C extends Config = Config>(
   nodes: any,
   options?: C
-): any {
+): MaybePromise<any> {
   const config = mergeConfig(options);
   const content = resolve(nodes, config);
 
-  if (Array.isArray(content))
-    return content.flatMap((child) => child.transform(config));
-  return content.transform(config);
+  if (Array.isArray(content)) {
+    const results = content.flatMap<MaybePromise<RenderableTreeNodes>>(
+      (child) => child.transform(config)
+    );
+    if (results.some(isPromise)) {
+      return Promise.all(results).then((resolved) =>
+        resolved.flatMap<RenderableTreeNode>((r) => (Array.isArray(r) ? r : [r]))
+      );
+    }
+    return (results as RenderableTreeNodes[]).flatMap<RenderableTreeNode>((r) =>
+      Array.isArray(r) ? r : [r]
+    );
+  }
+
+  return content.transform(config) as MaybePromise<RenderableTreeNode>;
 }
 
 export function validate<C extends Config = Config>(

--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,9 @@ export function transform<C extends Config = Config>(
     );
     if (results.some(isPromise)) {
       return Promise.all(results).then((resolved) =>
-        resolved.flatMap<RenderableTreeNode>((r) => (Array.isArray(r) ? r : [r]))
+        resolved.flatMap<RenderableTreeNode>((r) =>
+          Array.isArray(r) ? r : [r]
+        )
       );
     }
     return (results as RenderableTreeNodes[]).flatMap<RenderableTreeNode>((r) =>

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -90,7 +90,8 @@ describe('transform', function () {
           heading: {
             ...nodes.heading,
             async transform(node, config) {
-              const text = node.children[0]?.children[0]?.attributes?.content ?? '';
+              const text =
+                node.children[0]?.children[0]?.attributes?.content ?? '';
               order.push(text);
               return new Tag('h1', {}, [text]);
             },

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,0 +1,113 @@
+import Markdoc, { nodes } from '../index';
+import type { Config, RenderableTreeNode } from './types';
+import Tag from './tag';
+
+describe('transform', function () {
+  describe('synchronous transform', function () {
+    it('returns RenderableTreeNode for a single Node', function () {
+      const doc = `Hello **world**`;
+      const node = Markdoc.parse(doc);
+      const result = Markdoc.transform(node);
+      expect(result instanceof Promise).toBe(false);
+      expect(result instanceof Tag).toBe(true);
+    });
+
+    it('returns RenderableTreeNode[] for a Node[]', function () {
+      const doc = `Hello`;
+      const node = Markdoc.parse(doc);
+      const result = Markdoc.transform(node.children);
+      expect(result instanceof Promise).toBe(false);
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('async transform support', function () {
+    it('returns a Promise when a node schema uses an async transform', async function () {
+      const doc = `# Heading`;
+
+      const config: Config = {
+        nodes: {
+          heading: {
+            ...nodes.heading,
+            async transform(node, config) {
+              const text = await Promise.resolve('async heading');
+              return new Tag('h1', {}, [text]);
+            },
+          },
+        },
+      };
+
+      const ast = Markdoc.parse(doc);
+      const result = Markdoc.transform(ast, config);
+      // With an async transformer, the result should be a Promise
+      expect(result instanceof Promise).toBe(true);
+
+      const resolved = await result;
+      expect(resolved instanceof Tag).toBe(true);
+      // The document root is 'article'; the heading is a child
+      const heading = (resolved as Tag).children.find(
+        (c) => c instanceof Tag && (c as Tag).name === 'h1'
+      );
+      expect(heading).toBeDefined();
+      expect((heading as Tag).children[0]).toBe('async heading');
+    });
+
+    it('returns a Promise for Node[] when any child uses an async transform', async function () {
+      const doc = `# Heading\n\nParagraph`;
+
+      const config: Config = {
+        nodes: {
+          heading: {
+            ...nodes.heading,
+            async transform(node, config) {
+              const text = await Promise.resolve('async heading');
+              return new Tag('h1', {}, [text]);
+            },
+          },
+        },
+      };
+
+      const ast = Markdoc.parse(doc);
+      const result = Markdoc.transform(ast.children, config);
+      // With an async transformer on at least one child, result should be a Promise
+      expect(result instanceof Promise).toBe(true);
+
+      const resolved = await result;
+      expect(Array.isArray(resolved)).toBe(true);
+
+      const headings = (resolved as RenderableTreeNode[]).filter(
+        (r) => r instanceof Tag && (r as Tag).name === 'h1'
+      );
+      expect(headings.length).toBe(1);
+    });
+
+    it('resolves async Node[] transforms in document order', async function () {
+      const doc = `# First\n\n# Second`;
+      const order: string[] = [];
+
+      const config: Config = {
+        nodes: {
+          heading: {
+            ...nodes.heading,
+            async transform(node, config) {
+              const text = node.children[0]?.children[0]?.attributes?.content ?? '';
+              order.push(text);
+              return new Tag('h1', {}, [text]);
+            },
+          },
+        },
+      };
+
+      const ast = Markdoc.parse(doc);
+      const result = await Markdoc.transform(ast.children, config);
+      expect(Array.isArray(result)).toBe(true);
+
+      const tags = (result as RenderableTreeNode[]).filter(
+        (r) => r instanceof Tag && (r as Tag).name === 'h1'
+      );
+      expect(tags.length).toBe(2);
+      expect((tags[0] as Tag).children[0]).toBe('First');
+      expect((tags[1] as Tag).children[0]).toBe('Second');
+    });
+  });
+});

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -29,7 +29,7 @@ describe('transform', function () {
         nodes: {
           heading: {
             ...nodes.heading,
-            async transform(node, config) {
+            async transform(_node, _config) {
               const text = await Promise.resolve('async heading');
               return new Tag('h1', {}, [text]);
             },
@@ -59,7 +59,7 @@ describe('transform', function () {
         nodes: {
           heading: {
             ...nodes.heading,
-            async transform(node, config) {
+            async transform(_node, _config) {
               const text = await Promise.resolve('async heading');
               return new Tag('h1', {}, [text]);
             },
@@ -89,7 +89,7 @@ describe('transform', function () {
         nodes: {
           heading: {
             ...nodes.heading,
-            async transform(node, config) {
+            async transform(node, _config) {
               const text =
                 node.children[0]?.children[0]?.attributes?.content ?? '';
               order.push(text);


### PR DESCRIPTION
## Summary

Fixes #495.

`Markdoc.transform()` declared sync-only return types (`RenderableTreeNode` / `RenderableTreeNode[]`) even though `Node.transform()` already returns `MaybePromise<RenderableTreeNodes>`. This made it impossible for callers to correctly type-check or `await` async transforms.

---

## Root Cause

In `index.ts`, the two exported overload signatures for `transform()` were:

```typescript
export function transform(node: Node, config?: C): RenderableTreeNode;
export function transform(nodes: Node[], config?: C): RenderableTreeNode[];
```

But `Node.transform()` (in `src/ast/node.ts:81`) returns `MaybePromise<RenderableTreeNodes>`, meaning schemas that define an `async transform()` would produce a `Promise` at runtime — yet the declared return type claimed it was always synchronous. TypeScript would flag any `await Markdoc.transform(...)` call as "result is not a Promise".

Additionally, the array path in the implementation called `content.flatMap((child) => child.transform(config))` without checking for `Promise` results, so async children would be silently embedded in the returned array as unresolved `Promise` objects rather than being correctly awaited.

---

## Solution

1. **Update overload signatures** to `MaybePromise<RenderableTreeNode>` / `MaybePromise<RenderableTreeNode[]>`, matching the return type contract already established by `Node.transform()`.

2. **Fix the array-case implementation** to mirror the `Promise.all` pattern already used in `transformer.children()` (`src/transformer.ts:62-68`): collect child results, check if any are Promises, and if so return `Promise.all(results).then(...)`.

---

## Testing

Added `src/transformer.test.ts` with 5 tests covering:
- Sync path: single `Node` returns non-Promise `Tag`
- Sync path: `Node[]` returns non-Promise `RenderableTreeNode[]`  
- Async path: single `Node` with async schema returns a `Promise<Tag>`
- Async path: `Node[]` where one child uses async schema returns `Promise<RenderableTreeNode[]>`
- Async path: document-order preservation across multiple async transforms

All 264 existing specs pass. `tsc --noEmit` clean (pre-existing React errors in renderers unaffected).

Run with:
```
npm test
npm run type:check
```

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New tests cover the exact failing scenario from the issue
- [x] All existing tests pass (264 specs, 0 failures)
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md and followed its requirements