### PR TITLE
Disable markdoc tag in link href in tokenizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -20,7 +20,7 @@ export default class Tokenizer {
     this.parser = new MarkdownIt(config);
     this.parser.use(annotations, 'annotations', {});
     this.parser.use(frontmatter, 'frontmatter', {});
-    // Default to URL protocols to check for invalid hrefs
+    // Set http and https as the default protocols to validate
     this.parser.use(
       link,
       config.linkValidationOptions ?? { validatedProtocols: ['http', 'https'] }

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -2,6 +2,7 @@ import MarkdownIt from 'markdown-it/lib';
 import annotations from './plugins/annotations';
 import frontmatter from './plugins/frontmatter';
 import comments from './plugins/comments';
+import link from './plugins/link';
 import type Token from 'markdown-it/lib/token';
 
 export default class Tokenizer {
@@ -16,6 +17,7 @@ export default class Tokenizer {
     this.parser = new MarkdownIt(config);
     this.parser.use(annotations, 'annotations', {});
     this.parser.use(frontmatter, 'frontmatter', {});
+    this.parser.use(link, 'link_url_validation', {});
     this.parser.disable([
       'lheading',
       // Disable indented `code_block` support https://spec.commonmark.org/0.30/#indented-code-block

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -5,6 +5,8 @@ import comments from './plugins/comments';
 import link from './plugins/link';
 import type Token from 'markdown-it/lib/token';
 
+export type LinkPluginOptions = { validatedProtocols: string[] };
+
 export default class Tokenizer {
   private parser: MarkdownIt;
 
@@ -12,12 +14,17 @@ export default class Tokenizer {
     config: MarkdownIt.Options & {
       allowIndentation?: boolean;
       allowComments?: boolean;
+      linkValidationOptions?: LinkPluginOptions;
     } = {}
   ) {
     this.parser = new MarkdownIt(config);
     this.parser.use(annotations, 'annotations', {});
     this.parser.use(frontmatter, 'frontmatter', {});
-    this.parser.use(link, 'link_url_validation', {});
+    // Default to URL protocols to check for invalid hrefs
+    this.parser.use(
+      link,
+      config.linkValidationOptions ?? { validatedProtocols: ['http', 'https'] }
+    );
     this.parser.disable([
       'lheading',
       // Disable indented `code_block` support https://spec.commonmark.org/0.30/#indented-code-block

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -14,17 +14,14 @@ export default class Tokenizer {
     config: MarkdownIt.Options & {
       allowIndentation?: boolean;
       allowComments?: boolean;
+      allowLinkValidation?: boolean;
       linkValidationOptions?: LinkPluginOptions;
     } = {}
   ) {
     this.parser = new MarkdownIt(config);
     this.parser.use(annotations, 'annotations', {});
     this.parser.use(frontmatter, 'frontmatter', {});
-    // Set http and https as the default protocols to validate
-    this.parser.use(
-      link,
-      config.linkValidationOptions ?? { validatedProtocols: ['http', 'https'] }
-    );
+
     this.parser.disable([
       'lheading',
       // Disable indented `code_block` support https://spec.commonmark.org/0.30/#indented-code-block
@@ -32,6 +29,15 @@ export default class Tokenizer {
     ]);
 
     if (config.allowComments) this.parser.use(comments, 'comments', {});
+    if (config.allowLinkValidation) {
+      // Set http and https as the default protocols to validate
+      this.parser.use(
+        link,
+        config.linkValidationOptions ?? {
+          validatedProtocols: ['http', 'https'],
+        }
+      );
+    }
   }
 
   tokenize(content: string): Token[] {

--- a/src/tokenizer/plugins/link.test.ts
+++ b/src/tokenizer/plugins/link.test.ts
@@ -1,9 +1,10 @@
 import Tokenizer from '..';
 
 describe('MarkdownIt Link plugin', function () {
-  const tokenizer = new Tokenizer();
-
-  function parse(example) {
+  function parse(
+    example: string,
+    tokenizer: Tokenizer = new Tokenizer({ allowLinkValidation: true })
+  ) {
     const content = example.replace(/\n\s+/gm, '\n').trim();
     return tokenizer.tokenize(content);
   }
@@ -11,6 +12,11 @@ describe('MarkdownIt Link plugin', function () {
   function getInlineError(tokens) {
     return tokens.find((token) => token.type === 'inline')?.errors?.[0];
   }
+
+  it('accepts valid link urls and markdoc tag in one paragraph', function () {
+    const tokens = parse(`The link is https://example.com. {% tag /%})`);
+    expect(getInlineError(tokens)).toBeUndefined();
+  });
 
   it('accepts raw tag content in markdown link format', function () {
     const tokens = parse(`[Link]({% tag %})`);
@@ -62,6 +68,23 @@ describe('MarkdownIt Link plugin', function () {
   it('rejects non self-closing tags in markdown link urls', function () {
     const tokens = parse(
       `[Link](https://example.com/{% tag %}content{% /tag %})`
+    );
+    expect(getInlineError(tokens)).toDeepEqualSubset({
+      id: 'href-format-invalid',
+      level: 'error',
+      message:
+        "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
+    });
+  });
+
+  it('rejects custom protocols defined in the config with markdoc variable', function () {
+    const tokenizer = new Tokenizer({
+      allowLinkValidation: true,
+      linkValidationOptions: { validatedProtocols: ['vscode'] },
+    });
+    const tokens = parse(
+      `[Link](vscode://{% $variable.custom_value %})`,
+      tokenizer
     );
     expect(getInlineError(tokens)).toDeepEqualSubset({
       id: 'href-format-invalid',

--- a/src/tokenizer/plugins/link.test.ts
+++ b/src/tokenizer/plugins/link.test.ts
@@ -12,12 +12,12 @@ describe('MarkdownIt Link plugin', function () {
     return tokens.find((token) => token.type === 'inline')?.errors?.[0];
   }
 
-  it ('accepts raw tag content in markdown link format', function () {
+  it('accepts raw tag content in markdown link format', function () {
     const tokens = parse(`[Link]({% tag %})`);
     expect(getInlineError(tokens)).toBeUndefined();
-  })
+  });
 
-  it ('rejects plain link url with tags', function () {
+  it('rejects plain link url with tags', function () {
     const tokens = parse(`https://example.com/{% tag %}content{% /tag %})`);
     expect(getInlineError(tokens)).toDeepEqualSubset({
       id: 'href-format-invalid',
@@ -25,17 +25,19 @@ describe('MarkdownIt Link plugin', function () {
       message:
         "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
     });
-  })
+  });
 
-  it ('rejects URL with parenthesis in link', function () {
-    const tokens = parse(`https://en.wikipedia.org/wiki/Exam_(disambiguation){% tag /%}`)
+  it('rejects URL with parenthesis in link', function () {
+    const tokens = parse(
+      `https://en.wikipedia.org/wiki/Exam_(disambiguation){% tag /%}`
+    );
     expect(getInlineError(tokens)).toDeepEqualSubset({
       id: 'href-format-invalid',
       level: 'error',
       message:
         "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
     });
-  })
+  });
 
   it('rejects variables in markdown link urls', function () {
     const tokens = parse(`[Link](https://{% $variable.custom_value %})`);

--- a/src/tokenizer/plugins/link.test.ts
+++ b/src/tokenizer/plugins/link.test.ts
@@ -12,6 +12,31 @@ describe('MarkdownIt Link plugin', function () {
     return tokens.find((token) => token.type === 'inline')?.errors?.[0];
   }
 
+  it ('accepts raw tag content in markdown link format', function () {
+    const tokens = parse(`[Link]({% tag %})`);
+    expect(getInlineError(tokens)).toBeUndefined();
+  })
+
+  it ('rejects plain link url with tags', function () {
+    const tokens = parse(`https://example.com/{% tag %}content{% /tag %})`);
+    expect(getInlineError(tokens)).toDeepEqualSubset({
+      id: 'href-format-invalid',
+      level: 'error',
+      message:
+        "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
+    });
+  })
+
+  it ('rejects URL with parenthesis in link', function () {
+    const tokens = parse(`https://en.wikipedia.org/wiki/Exam_(disambiguation){% tag /%}`)
+    expect(getInlineError(tokens)).toDeepEqualSubset({
+      id: 'href-format-invalid',
+      level: 'error',
+      message:
+        "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
+    });
+  })
+
   it('rejects variables in markdown link urls', function () {
     const tokens = parse(`[Link](https://{% $variable.custom_value %})`);
     expect(getInlineError(tokens)).toDeepEqualSubset({

--- a/src/tokenizer/plugins/link.test.ts
+++ b/src/tokenizer/plugins/link.test.ts
@@ -1,0 +1,46 @@
+import Tokenizer from '..';
+
+describe('MarkdownIt Link plugin', function () {
+  const tokenizer = new Tokenizer();
+
+  function parse(example) {
+    const content = example.replace(/\n\s+/gm, '\n').trim();
+    return tokenizer.tokenize(content);
+  }
+
+  function getInlineError(tokens) {
+    return tokens.find((token) => token.type === 'inline')?.errors?.[0];
+  }
+
+  it('rejects variables in markdown link urls', function () {
+    const tokens = parse(`[Link](https://{% $variable.custom_value %})`);
+    expect(getInlineError(tokens)).toDeepEqualSubset({
+      id: 'href-format-invalid',
+      level: 'error',
+      message:
+        "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
+    });
+  });
+
+  it('rejects self-closing tags in markdown link urls', function () {
+    const tokens = parse(`[Link](https://example.com/{% tag /%})`);
+    expect(getInlineError(tokens)).toDeepEqualSubset({
+      id: 'href-format-invalid',
+      level: 'error',
+      message:
+        "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
+    });
+  });
+
+  it('rejects non self-closing tags in markdown link urls', function () {
+    const tokens = parse(
+      `[Link](https://example.com/{% tag %}content{% /tag %})`
+    );
+    expect(getInlineError(tokens)).toDeepEqualSubset({
+      id: 'href-format-invalid',
+      level: 'error',
+      message:
+        "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.",
+    });
+  });
+});

--- a/src/tokenizer/plugins/link.ts
+++ b/src/tokenizer/plugins/link.ts
@@ -1,0 +1,41 @@
+import type MarkdownIt from 'markdown-it/lib';
+import type StateCore from 'markdown-it/lib/rules_core/state_core';
+import type Token from 'markdown-it/lib/token';
+import type { ValidationError } from '../../types';
+
+import { TAG_PATTERN } from '../../utils';
+
+const MARKDOWN_LINK_DESTINATION = /\[[^\]]+\]\(([^)\n]+)\)/g;
+const INVALID_HREF_MESSAGE =
+  "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.";
+
+type TokenWithErrors = Token & { errors?: ValidationError[] };
+
+function pushHrefError(token: Token) {
+  const tokenWithErrors = token as TokenWithErrors;
+  if (!tokenWithErrors.errors) tokenWithErrors.errors = [];
+  tokenWithErrors.errors.push({
+    id: 'href-format-invalid',
+    level: 'error',
+    message: INVALID_HREF_MESSAGE,
+  });
+}
+
+function core(state: StateCore) {
+  let token: Token;
+  for (token of state.tokens) {
+    if (token.type !== 'inline' || typeof token.content !== 'string') continue;
+
+    const matches = token.content.match(MARKDOWN_LINK_DESTINATION) || [];
+    const invalidLink = matches.find((linkSource) =>
+      TAG_PATTERN.test(linkSource)
+    );
+    if (!invalidLink) continue;
+
+    pushHrefError(token);
+  }
+}
+
+export default function plugin(md: MarkdownIt) {
+  md.core.ruler.push('link_url_validation', core);
+}

--- a/src/tokenizer/plugins/link.ts
+++ b/src/tokenizer/plugins/link.ts
@@ -4,6 +4,7 @@ import type Token from 'markdown-it/lib/token';
 import type { ValidationError } from '../../types';
 
 import { containsMarkdocTagInUrl } from '../../utils';
+import { LinkPluginOptions } from '..';
 
 const INVALID_HREF_MESSAGE =
   "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.";
@@ -20,17 +21,17 @@ function pushHrefError(token: Token) {
   });
 }
 
-function core(state: StateCore) {
+function core(state: StateCore, options: LinkPluginOptions) {
   let token: Token;
   for (token of state.tokens) {
     if (token.type !== 'inline' || typeof token.content !== 'string') continue;
 
-    if (containsMarkdocTagInUrl(token.content)) {
+    if (containsMarkdocTagInUrl(token.content, options.validatedProtocols)) {
       pushHrefError(token);
     }
   }
 }
 
-export default function plugin(md: MarkdownIt) {
-  md.core.ruler.push('link_url_validation', core);
+export default function plugin(md: MarkdownIt, options: LinkPluginOptions) {
+  md.core.ruler.push('link_url_validation', (state) => core(state, options));
 }

--- a/src/tokenizer/plugins/link.ts
+++ b/src/tokenizer/plugins/link.ts
@@ -3,9 +3,8 @@ import type StateCore from 'markdown-it/lib/rules_core/state_core';
 import type Token from 'markdown-it/lib/token';
 import type { ValidationError } from '../../types';
 
-import { TAG_PATTERN } from '../../utils';
+import { containsMarkdocTagInUrl } from '../../utils';
 
-const MARKDOWN_LINK_DESTINATION = /\[[^\]]+\]\(([^)\n]+)\)/g;
 const INVALID_HREF_MESSAGE =
   "The 'href' format cannot contain Markdoc tag or variable. URLs must be static strings.";
 
@@ -26,13 +25,9 @@ function core(state: StateCore) {
   for (token of state.tokens) {
     if (token.type !== 'inline' || typeof token.content !== 'string') continue;
 
-    const matches = token.content.match(MARKDOWN_LINK_DESTINATION) || [];
-    const invalidLink = matches.find((linkSource) =>
-      TAG_PATTERN.test(linkSource)
-    );
-    if (!invalidLink) continue;
-
-    pushHrefError(token);
+    if (containsMarkdocTagInUrl(token.content)) {
+      pushHrefError(token);
+    }
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function containsMarkdocTagInUrl(
 
     // Check if the content contains the URL.
     for (const protocol of allowedProtocols) {
-      if (content.slice(start, pos).includes(protocol)) {
+      if (content.slice(start, pos).includes(`${protocol}://`)) {
         return true;
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,6 @@ enum STATES {
 
 export const OPEN = '{%';
 export const CLOSE = '%}';
-export const TAG_PATTERN = /\{%\s*[\s\S]*?%\}/;
 
 export const IDENTIFIER_REGEX = /^[a-zA-Z0-9_-]+$/;
 
@@ -50,6 +49,31 @@ export function findTagEnd(content: string, start = 0) {
   }
 
   return null;
+}
+
+export function containsMarkdocTagInUrl(content: string) {
+  for (let pos = 0; pos < content.length; pos++) {
+    if (!content.startsWith(OPEN, pos)) continue;
+
+    const end = findTagEnd(content, pos);
+    if (end === null) {
+      // If we cannot find the closing tag, we skip over it
+      pos += OPEN.length - 1;
+      continue;
+    }
+
+    // Locate the start of the content from the tag start (stop tracing the starting position when it hits the first whitespace)
+    let start = pos;
+    while (start > 0 && !/\s/.test(content[start - 1])) start--;
+
+    // Check if the content contains the URL.
+    if (content.slice(start, pos).includes('https://')) {
+      return true;
+    }
+
+  }
+
+  return false;
 }
 
 function parseTag(content: string, line: number, contentStart: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,6 @@ export function containsMarkdocTagInUrl(content: string) {
     if (content.slice(start, pos).includes('https://')) {
       return true;
     }
-
   }
 
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,10 @@ export function findTagEnd(content: string, start = 0) {
   return null;
 }
 
-export function containsMarkdocTagInUrl(content: string) {
+export function containsMarkdocTagInUrl(
+  content: string,
+  allowedProtocols: string[]
+) {
   for (let pos = 0; pos < content.length; pos++) {
     if (!content.startsWith(OPEN, pos)) continue;
 
@@ -67,9 +70,12 @@ export function containsMarkdocTagInUrl(content: string) {
     while (start > 0 && !/\s/.test(content[start - 1])) start--;
 
     // Check if the content contains the URL.
-    if (content.slice(start, pos).includes('https://')) {
-      return true;
+    for (const protocol of allowedProtocols) {
+      if (content.slice(start, pos).includes(protocol)) {
+        return true;
+      }
     }
+    return false;
   }
 
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ enum STATES {
 
 export const OPEN = '{%';
 export const CLOSE = '%}';
+export const TAG_PATTERN = /\{%\s*[\s\S]*?%\}/;
 
 export const IDENTIFIER_REGEX = /^[a-zA-Z0-9_-]+$/;
 


### PR DESCRIPTION
Markdoc doesn't have any validation to fail the use of markdoc variables or tags (i.e. `{% %}` format) in link href. 

In this PR, we capture the link format in the tokenizer, and push an error when the tag format is found in the href. 

Another option is to run the validation in [link schema](https://github.com/markdoc/markdoc/blob/main/src/schema.ts#L207-L214), but the problem is that the default markdown parsing doesn't parse the content as link when space is included in the href. For example, `[Link](https://{%tag%})` can be parsed, but `[Link](https://{% tag %})` can't be parsed.

This is why I choose to add a plugin for the tokenizer and throw an error there. This can ensure the default parsing is not changed while additional validation can be enforced.

This link validation is optional. It can be enabled through `allowLinkValidation` in the config. Custom protocol to validate (`validatedProtocols`) can be specified in `linkValidationOptions`. It's default to `http` and `https`.