### PR TITLE
Fix incorrectly escaped number signs in text

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -147,6 +147,8 @@ regular_word_with_underscores
 
 Text > not a blockquote
 
+Text # not a heading
+
 \\# Heading
 
 \\### Heading

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -224,7 +224,7 @@ function* formatNode(n: Node, o: Options = {}) {
           yield* escapeMarkdownCharacters(content, /[*_~]/g);
         } else {
           // Escape > blockquote, * list item, and heading
-          yield* escapeMarkdownCharacters(content, /^\*|#+\s|^>/);
+          yield* escapeMarkdownCharacters(content, /^\*|^#+\s|^>/);
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/markdoc/markdoc/issues/637

#583 anchored the blockquote `>` escape to the start of a line, since `>` is only a block marker there. The same escape expression still matches the heading `#` anywhere in the text:

```js
escapeMarkdownCharacters(content, /^\*|#+\s|^>/)
```

So a `#` that follows other text gets escaped even though it can't start a heading:

- `Text # not a heading` → `Text \# not a heading`
- `C# is a language` → `C\# is a language`

This anchors `#+\s` to the start of the line as well, matching `^\*` and `^>`. A leading `#` in literal text is still escaped, so `\# Heading` keeps round-tripping unchanged.

The fixture in the existing "escape markdown content" test gains a `Text # not a heading` line, which fails before the change.
