### PR TITLE
Use npm trusted publishing in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -18,6 +19,4 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Basically make #630 manually. Something may be wrong with Copilot. The build can't pass on that PR.

---

The failing `build` job was in the release workflow, not CI validation: the package built successfully, then `npm publish` failed against the npm registry. This updates the publish step to use GitHub Actions OIDC trusted publishing instead of the legacy token-based flow.

- **Root cause**
  - `release.yml` still authenticated `npm publish` with `NODE_AUTH_TOKEN` / `NPM_TOKEN`
  - the publish step failed after a successful build when attempting to publish `@markdoc/markdoc@0.5.8`

- **Workflow update**
  - grant `id-token: write` to the release job
  - remove the explicit `NODE_AUTH_TOKEN` env wiring
  - publish with provenance enabled via npm trusted publishing

- **Net effect**
  - release publishes no longer depend on the deprecated token-based npm auth path
  - package publishing aligns with current GitHub Actions + npm OIDC flow

```yaml
permissions:
  contents: read
  id-token: write

# ...

- run: npm publish --provenance --access public
```