### PR TITLE
Allow softbreak as a child of `em` and `strong` nodes

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -169,7 +169,7 @@ export const thead: Schema = {
 
 export const strong: Schema = {
   render: 'strong',
-  children: ['em', 's', 'link', 'code', 'text', 'tag'],
+  children: ['em', 's', 'link', 'code', 'text', 'tag', 'softbreak'],
   attributes: {
     marker: { type: String, render: false },
   },
@@ -177,7 +177,7 @@ export const strong: Schema = {
 
 export const em: Schema = {
   render: 'em',
-  children: ['strong', 's', 'link', 'code', 'text', 'tag'],
+  children: ['strong', 's', 'link', 'code', 'text', 'tag', 'softbreak'],
   attributes: {
     marker: { type: String, render: false },
   },


### PR DESCRIPTION
Sandbox: https://markdoc.dev/sandbox?mode=preview&c=LS0tCnRpdGxlOiBzb2Z0YnJlYWsgaW4gZW0gYW5kIHN0cm9uZwotLS0KCipzb21lIGVtcGhhc2l6ZWQKdGV4dCoKCioqc29tZSBzdHJvbmcKdGV4dCoqCg%253D%253D

These are flagged as warnings, but render without problem.