### PR TITLE
Make Schema.children strongly typed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,9 +100,11 @@ export type RenderableTreeNodes = RenderableTreeNode | RenderableTreeNode[];
 
 export type Scalar = Primitive | Scalar[] | { [key: string]: Scalar };
 
+export type SchemaChild = NodeType;
+
 export type Schema<C extends Config = Config, R = string> = {
   render?: R;
-  children?: string[];
+  children?: SchemaChild[];
   attributes?: Record<string, SchemaAttribute>;
   slots?: Record<string, SchemaSlot>;
   selfClosing?: boolean;


### PR DESCRIPTION
## Summary
- type `Schema.children` as `NodeType[]`
- bump the package version from 0.5.8 to 0.5.9

## Why
`Schema.children` gets used during invalid child validation in src/validator.ts:
https://github.com/markdoc/markdoc/blob/d351d70f685eb16681f2a8bf1f07fcdf496611fd/src/validator.ts#L278-L285

That logic checks each parsed child node type against `schema.children` at runtime. If a schema supplies an unsupported child value, it is silently ignored because it never matches any parsed node type. Strongly typing `children` turns that mistake into a type error instead of letting it slip through and misleading users into thinking providing a tag name will enable validation.

## Testing
- npm run type:check passes