### PR TITLE
Added validation for custom children tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.5.8",
+      "version": "0.5.10",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdoc/markdoc",
   "author": "Ryan Paul",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "A text markup language for documentation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,18 @@ export type RenderableTreeNodes = RenderableTreeNode | RenderableTreeNode[];
 
 export type Scalar = Primitive | Scalar[] | { [key: string]: Scalar };
 
-export type SchemaChild = NodeType;
+/**
+ * A `NodeType` restricts children by generic node kind (e.g. 'tag' allows any tag).
+ * A `tag:<name>` entry restricts to one specific tag by name; once any `tag:` entry
+ * is present, tag children are matched only against those entries, not the generic 'tag' type.
+ * 
+ * Example usage:
+ * {
+ *   children: ['tag:foo', 'tag:bar', 'paragraph']
+ * }
+ * This allows 'foo' and 'bar' tags, and 'paragraph' nodes, but no other tags or nodes.
+ */
+export type SchemaChild = NodeType | `tag:${string}`;
 
 export type Schema<C extends Config = Config, R = string> = {
   render?: R;

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export type Scalar = Primitive | Scalar[] | { [key: string]: Scalar };
  * A `NodeType` restricts children by generic node kind (e.g. 'tag' allows any tag).
  * A `tag:<name>` entry restricts to one specific tag by name; once any `tag:` entry
  * is present, tag children are matched only against those entries, not the generic 'tag' type.
- * 
+ *
  * Example usage:
  * {
  *   children: ['tag:foo', 'tag:bar', 'paragraph']

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -747,10 +747,7 @@ bar
         },
       };
 
-      const output = validate(
-        `{% list %}{% card /%}{% /list %}`,
-        config
-      );
+      const output = validate(`{% list %}{% card /%}{% /list %}`, config);
 
       expect(output).toDeepEqualSubset([
         {

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -708,4 +708,87 @@ bar
       validate(doc, config);
     });
   });
+
+  describe('children validation', () => {
+    it('restricts children to specific tags via the tag: prefix', () => {
+      const config: Config = {
+        tags: {
+          'card-group': { children: ['tag:card'] },
+          card: {},
+          other: {},
+        },
+      };
+
+      const valid = validate(
+        `{% card-group %}{% card /%}{% /card-group %}`,
+        config
+      );
+      expect(valid).toDeepEqual([]);
+
+      const invalid = validate(
+        `{% card-group %}{% other /%}{% /card-group %}`,
+        config
+      );
+      expect(invalid).toDeepEqualSubset([
+        {
+          error: {
+            id: 'child-invalid',
+            message: "Can't nest 'other' in 'card-group'",
+          },
+        },
+      ]);
+    });
+
+    it('falls back to generic type matching when no tag: entries are present', () => {
+      const config: Config = {
+        tags: {
+          list: { children: ['item'] },
+          card: {},
+        },
+      };
+
+      const output = validate(
+        `{% list %}{% card /%}{% /list %}`,
+        config
+      );
+
+      expect(output).toDeepEqualSubset([
+        {
+          error: {
+            id: 'child-invalid',
+            message: "Can't nest 'card' in 'list'",
+          },
+        },
+      ]);
+    });
+
+    it('allows mixing generic types with specific tag names', () => {
+      const config: Config = {
+        tags: {
+          'card-group': { children: ['paragraph', 'tag:card'] },
+          card: {},
+          other: {},
+        },
+      };
+
+      const doc = `
+{% card-group %}
+plain text
+
+{% other /%}
+{% /card-group %}
+`;
+
+      const output = validate(doc, config);
+
+      expect(output).toDeepEqualSubset([
+        {
+          error: {
+            id: 'child-invalid',
+            message: "Can't nest 'other' in 'card-group'",
+          },
+        },
+      ]);
+    });
+  });
 });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -275,13 +275,28 @@ export default function validator(node: Node, config: Config) {
           message: `Missing required slot: '${key}'`,
         });
 
-  for (const { type } of node.children) {
-    if (schema.children && type !== 'error' && !schema.children.includes(type))
-      errors.push({
-        id: 'child-invalid',
-        level: 'warning',
-        message: `Can't nest '${type}' in '${node.tag || node.type}'`,
-      });
+  if (schema.children) {
+    const tagEntries = schema.children.filter((child) =>
+      child.startsWith('tag:')
+    );
+
+    for (const child of node.children) {
+      if (child.type === 'error') continue;
+
+      const allowed =
+        child.type === 'tag' && tagEntries.length > 0
+          ? tagEntries.includes(`tag:${child.tag}`)
+          : schema.children.includes(child.type);
+
+      if (!allowed)
+        errors.push({
+          id: 'child-invalid',
+          level: 'warning',
+          message: `Can't nest '${
+            child.tag ?? child.type
+          }' in '${node.tag || node.type}'`,
+        });
+    }
   }
 
   if (schema.validate) {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -292,9 +292,9 @@ export default function validator(node: Node, config: Config) {
         errors.push({
           id: 'child-invalid',
           level: 'warning',
-          message: `Can't nest '${
-            child.tag ?? child.type
-          }' in '${node.tag || node.type}'`,
+          message: `Can't nest '${child.tag ?? child.type}' in '${
+            node.tag || node.type
+          }'`,
         });
     }
   }


### PR DESCRIPTION
This PR updates `children` attribute to allow validation for custom tags in addition to the Markdoc nodes. Individual tags have to be prefixed with `tag:` string.

### Usage
```js
{
  children: ['paragraph', 'tag'] // `paragraph` node and any custom tags are allowed.
}
```

```js
{
  children: ['paragraph', 'tag:card'] // `paragraph` node and the `card` tag is allowed. Any other tags inside this component will throw a validation error.
}
```