### PR TITLE
Fix package-lock.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/markdoc",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/markdoc",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",


### PR DESCRIPTION
The version in `package.json` wasn't matching `package-lock.json`. I updated it by running `npm i` which aligned the versions.