### PR TITLE
Formatter: prefix every line of a blockquote's children with `> `

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -833,6 +833,61 @@ ${'`'.repeat(4)}
     check(source, expected);
     stable(expected);
   });
+  it('lists in blockquotes', () => {
+    const source = `
+> Intro:
+>
+> - One
+> - Two
+>
+> 1. First
+> 2. Second
+>
+> After`;
+
+    const expected = `
+> Intro:
+> 
+> - One
+> - Two
+> 
+> 1. First
+> 1. Second
+> 
+> After
+`;
+
+    check(source, expected);
+    stable(expected);
+  });
+  it('nested blocks in blockquotes', () => {
+    const source = `
+> - One
+>   - Nested
+> - Two
+> 
+> > Inner
+> > quote
+> 
+> \`\`\`js
+> code();
+> \`\`\`
+`;
+
+    stable(source);
+  });
+  it('blockquotes with lists inside list items', () => {
+    const source = `
+- Item
+
+  > Quote
+  > 
+  > - One
+  > - Two
+`;
+
+    stable(source);
+  });
   it('skips over undefined variables', () => {
     const sourceNode = new Markdoc.Ast.Node(
       'tag',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -231,11 +231,11 @@ function* formatNode(n: Node, o: Options = {}) {
       break;
     }
     case 'blockquote': {
-      const prefix = '>' + SPACE;
-      yield n.children
-        .map((child) => format(child, no).trimStart())
-        .map((d) => NL + indent + prefix + d)
-        .join(indent + prefix);
+      const prefix = NL + indent + '>' + SPACE;
+      const inner = n.children
+        .map((child) => format(child, { ...no, indent: 0 }).trim())
+        .join(NL + NL);
+      yield prefix + inner.split(NL).join(prefix) + NL;
       break;
     }
     case 'hr': {


### PR DESCRIPTION
`format()` prefixes each child of a blockquote with `> ` on its first line only, so any child spanning several lines loses the quote on the rest. The multi-line sibling of #321, which fixed the two-paragraph case.

Input:

```
> Intro:
>
> - One
> - Two
```

Output on `main`:

```
> Intro:
> 
> - One
- Two
```

Nested blockquotes and fenced code inside a blockquote break the same way. Found via Keystatic, which writes files with `format()`: saving an essay with a quoted list silently restructured it.

Fix: format the children unindented, join them with a blank line, and prefix every line with `> ` at the blockquote's own indent, so a quote inside a list item still nests. Three tests added; all fail on `main`.
