### PR TITLE
Parse multi-line tag openings inside blockquotes

### DIFF
--- a/src/tokenizer/plugins/annotations.test.ts
+++ b/src/tokenizer/plugins/annotations.test.ts
@@ -167,6 +167,25 @@ describe('MarkdownIt Annotations plugin', function () {
         expect(example.length).toEqual(5);
         expect(example[2].children.length).toEqual(1);
       });
+
+      it('inside a blockquote', function () {
+        const example = parse(`
+        > {% test #foo .bar
+        >   baz=1 %}
+        > This is a test
+        > {% /test %}
+        `);
+
+        expect(example).toDeepEqualSubset([
+          { type: 'blockquote_open', nesting: 1 },
+          ...basicExample,
+          { type: 'blockquote_close', nesting: -1 },
+        ]);
+        expect(example[1].map).toDeepEqual([0, 2]);
+        expect(example[2].map).toDeepEqual([2, 3]);
+        expect(example[5].map).toDeepEqual([3, 4]);
+        expect(example.length).toEqual(7);
+      });
     });
 
     describe('inline', function () {

--- a/src/tokenizer/plugins/annotations.test.ts
+++ b/src/tokenizer/plugins/annotations.test.ts
@@ -186,6 +186,113 @@ describe('MarkdownIt Annotations plugin', function () {
         expect(example[5].map).toDeepEqual([3, 4]);
         expect(example.length).toEqual(7);
       });
+
+      it('followed by content after the blockquote', function () {
+        const example = parse(`
+        > {% test #foo .bar
+        >   baz=1 %}
+        > This is a test
+        > {% /test %}
+        After the blockquote
+        `);
+
+        expect(example).toDeepEqualSubset([
+          { type: 'blockquote_open', nesting: 1 },
+          ...basicExample,
+          { type: 'blockquote_close', nesting: -1 },
+          { type: 'paragraph_open', tag: 'p', nesting: 1 },
+          {
+            type: 'inline',
+            nesting: 0,
+            children: [
+              { type: 'text', nesting: 0, content: 'After the blockquote' },
+            ],
+          },
+          { type: 'paragraph_close', tag: 'p', nesting: -1 },
+        ]);
+        expect(example[1].map).toDeepEqual([0, 2]);
+        expect(example[5].map).toDeepEqual([3, 4]);
+        expect(example[7].map).toDeepEqual([4, 5]);
+        expect(example.length).toEqual(10);
+      });
+
+      it('inside a list item', function () {
+        // Not dedented: list continuation depends on the indentation
+        const example = tokenizer.tokenize(`- {% test #foo .bar
+    baz=1 %}
+  This is a test
+  {% /test %}`);
+
+        expect(example).toDeepEqualSubset([
+          { type: 'bullet_list_open', nesting: 1 },
+          { type: 'list_item_open', nesting: 1 },
+          ...basicExample,
+          { type: 'list_item_close', nesting: -1 },
+          { type: 'bullet_list_close', nesting: -1 },
+        ]);
+        expect(example[2].map).toDeepEqual([0, 2]);
+        expect(example[3].map).toDeepEqual([2, 3]);
+        expect(example[6].map).toDeepEqual([3, 4]);
+        expect(example.length).toEqual(9);
+      });
+
+      it('inside a list item inside a blockquote', function () {
+        const example = tokenizer.tokenize(`> - {% test #foo .bar
+>     baz=1 %}
+>   This is a test
+>   {% /test %}`);
+
+        expect(example).toDeepEqualSubset([
+          { type: 'blockquote_open', nesting: 1 },
+          { type: 'bullet_list_open', nesting: 1 },
+          { type: 'list_item_open', nesting: 1 },
+          ...basicExample,
+          { type: 'list_item_close', nesting: -1 },
+          { type: 'bullet_list_close', nesting: -1 },
+          { type: 'blockquote_close', nesting: -1 },
+        ]);
+        expect(example[3].map).toDeepEqual([0, 2]);
+        expect(example[4].map).toDeepEqual([2, 3]);
+        expect(example[7].map).toDeepEqual([3, 4]);
+        expect(example.length).toEqual(11);
+      });
+    });
+
+    it('with a single-line container inside a blockquote', function () {
+      const example = parse(`
+      > {% test #foo .bar baz=1 %}
+      > This is a test
+      > {% /test %}
+      `);
+
+      expect(example).toDeepEqualSubset([
+        { type: 'blockquote_open', nesting: 1 },
+        {
+          type: 'tag_open',
+          nesting: 1,
+          meta: {
+            attributes: [
+              { type: 'attribute', name: 'id', value: 'foo' },
+              { type: 'class', name: 'bar', value: true },
+              { type: 'attribute', name: 'baz', value: 1 },
+            ],
+            tag: 'test',
+          },
+        },
+        { type: 'paragraph_open', tag: 'p', nesting: 1 },
+        {
+          type: 'inline',
+          nesting: 0,
+          children: [{ type: 'text', nesting: 0, content: 'This is a test' }],
+        },
+        { type: 'paragraph_close', tag: 'p', nesting: -1 },
+        { type: 'tag_close', nesting: -1, meta: { tag: 'test' } },
+        { type: 'blockquote_close', nesting: -1 },
+      ]);
+      expect(example[1].map).toDeepEqual([0, 1]);
+      expect(example[2].map).toDeepEqual([1, 2]);
+      expect(example[5].map).toDeepEqual([2, 3]);
+      expect(example.length).toEqual(7);
     });
 
     describe('inline', function () {

--- a/src/tokenizer/plugins/annotations.ts
+++ b/src/tokenizer/plugins/annotations.ts
@@ -65,10 +65,13 @@ function block(
   if (!tagEnd || tagEnd < lastPossible - CLOSE.length) return false;
 
   const contentStart = start + OPEN.length;
-  const content = state.src.slice(contentStart, tagEnd).trim();
   const lines = state.src
     .slice(start, tagEnd + CLOSE.length)
     .split('\n').length;
+  const text = state.getLines(startLine, startLine + lines, 0, false);
+  const content = text
+    .slice(text.indexOf(OPEN) + OPEN.length, findTagEnd(text))
+    .trim();
 
   if (content[0] === '$') return false;
 


### PR DESCRIPTION
Fixes #641: a tag opening that spans several lines parses everywhere except inside a blockquote, where the `> ` markers of the continuation lines end up inside the tag text and the grammar rejects it.

This isn't just a hand-written edge case. `format()` wraps any tag opening longer than `maxTagOpeningWidth`, so a tool that formats on save (Keystatic, for one) turns a long callout inside a quote into an error node on the next parse.

Fix: read the tag's lines through `state.getLines`, which strips container markers the same way markdown-it's own block rules do. Single-line tags are unaffected. Test added beside the existing multi-line tag tests; it fails on `main`.

Independent of #640, which fixes the formatter side of the same round trip.
